### PR TITLE
Only initialise clients if they're not null

### DIFF
--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -134,11 +134,15 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             log.warn("ClientProvider instance is missing. The YouTube source will be initialised with default clients.");
             source = new YoutubeAudioSourceManager(allowSearch);
         } else {
-            Client[] clients = clientProvider.getClients(youtubeConfig.getClients());
-            source = new YoutubeAudioSourceManager(allowSearch, clients);
-            log.info("YouTube source initialised with clients: {} ", Arrays.stream(clients).map(Client::getIdentifier).collect(Collectors.joining(", ")));
+            if (youtubeConfig.getClients() != null) {
+                Client[] clients = clientProvider.getClients(youtubeConfig.getClients());
+                source = new YoutubeAudioSourceManager(allowSearch, clients);
+            } else {
+                source = new YoutubeAudioSourceManager(allowSearch);
+            }
         }
 
+        log.info("YouTube source initialised with clients: {} ", Arrays.stream(source.getClients()).map(Client::getIdentifier).collect(Collectors.joining(", ")));
         final AbstractRoutePlanner routePlanner = getRoutePlanner();
 
         if (routePlanner != null) {


### PR DESCRIPTION
Fixes an issue where the source manager can fail to initialise if the received client array is null.
Implements a check for this and uses default clients if null is provided.