### PR TITLE
Match direct video id

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -230,6 +230,12 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
             if (shortHandMatcher.matches()) {
                 return routeFromVideoId(httpInterface, shortHandMatcher.group("videoId"), null);
             }
+
+            Matcher directVideoIdMatcher = directVideoIdPattern.matcher(identifier);
+
+            if (directVideoIdMatcher.matches()) {
+                return routeFromVideoId(httpInterface, identifier, null);
+            }
         }
 
         return null;

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -219,6 +219,12 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
                 }
             }
 
+            Matcher directVideoIdMatcher = directVideoIdPattern.matcher(identifier);
+
+            if (directVideoIdMatcher.matches()) {
+                return routeFromVideoId(httpInterface, identifier, null);
+            }
+
             Matcher playlistIdMatcher = directPlaylistIdPattern.matcher(identifier);
 
             if (playlistIdMatcher.matches()) {
@@ -229,12 +235,6 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
 
             if (shortHandMatcher.matches()) {
                 return routeFromVideoId(httpInterface, shortHandMatcher.group("videoId"), null);
-            }
-
-            Matcher directVideoIdMatcher = directVideoIdPattern.matcher(identifier);
-
-            if (directVideoIdMatcher.matches()) {
-                return routeFromVideoId(httpInterface, identifier, null);
             }
         }
 


### PR DESCRIPTION
Adds a matcher for a direct video id, so it'll match them like the [old youtube router](https://github.com/lavalink-devs/lavaplayer/blob/0ab6311a5f1947a67afd5894bddbe182a0a8e513/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java#L27) does