### PR TITLE
Fixed typo in IP rotator example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ innertube clients) and `StreamingNonMusicClient` (for clients that can be used t
 
 Support for IP rotation has been included, and can be achieved using the following:
 ```java
-AbstractRouterPlanner routePlanner = new ...
+AbstractRoutePlanner routePlanner = new ...
 YoutubeIpRotatorSetup rotator = new YoutubeIpRotatorSetup(routePlanner);
 
 rotator.forConfiguration(youtube.getHttpInterfaceManager(), false)


### PR DESCRIPTION
Updated classname of AbstractRoutePlanner.

AbstractRouterPlanner does not exist.

I thought it was a typo so I fixed it, but if not, you can close this PR.