### PR TITLE
Improve Migration Guide for YoutubeAudioSourceManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Currently, the following clients are available for use:
 ## Migration from Lavaplayer's built-in YouTube source
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`,
-which may be deprecated in more recent releases of Lavaplayer.
+which has been deprecated in a recent release of Lavaplayer.
 By default, Lavaplayer instantiates and registers an instance of its `YoutubeAudioSourceManager` unless
 explicitly excluded.
 

--- a/README.md
+++ b/README.md
@@ -178,22 +178,22 @@ Currently, the following clients are available for use:
 
 ## Migration from Lavaplayer's built-in YouTube source
 
-This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
-deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer instantiates and registers an instance of its deprecated `YoutubeAudioSourceManager` unless 
+This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`,
+which may be deprecated in more recent releases of Lavaplayer.
+By default, Lavaplayer instantiates and registers an instance of its deprecated `YoutubeAudioSourceManager` unless
 explicitly excluded.
 
-To avoid this unwanted instantiation, leverage the `excludeSources` parameter during remote source registration.
+First, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManagers.registerRemoteSources(playerManager,
-                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
-```
-
-Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
-```java
 AudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
 playerManager.registerSourceManager(ytSourceManager);
+```
+
+Next, leverage the `excludeSources` parameter to avoid unwanted instantiations during remote source registration.
+```java
+AudioSourceManagers.registerRemoteSources(playerManager,
+                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
 ```
 
 In addition, there are a few significant changes to note:

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Therefore, you may leverage the `excludeSources` parameter to prevent instantiat
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
 AudioSourceManagers.registerRemoteSources(
-        playerManager, com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class
+        playerManager, 
+        com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Currently, the following clients are available for use:
     client enabled, age-restricted tracks are **not** guaranteed to play.
 
 ## Migration from Lavaplayer's built-in YouTube source
-This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`. Lavaplayer deprecated this class in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2); 
-however, it will continue to instantiate and register an instance unless explicitly excluded.
+This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
+However, Lavaplayer will continue to instantiate and register an instance of this class unless explicitly excluded.
 
-Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of the deprecated `YoutubeAudioSourceManager` class.
+Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of this deprecated `YoutubeAudioSourceManager` class.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
 AudioSourceManagers.registerRemoteSources(playerManager,

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Currently, the following clients are available for use:
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`,
 which may be deprecated in more recent releases of Lavaplayer.
-By default, Lavaplayer instantiates and registers an instance of its deprecated `YoutubeAudioSourceManager` unless
+By default, Lavaplayer instantiates and registers an instance of its `YoutubeAudioSourceManager` unless
 explicitly excluded.
 
 First, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.

--- a/README.md
+++ b/README.md
@@ -184,22 +184,16 @@ By default, Lavaplayer will continue to instantiate and register an instance of 
 deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
 Firstly, leverage the `excludeSources` parameter to prevent its instantiation.
-
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManagers.
-
-registerRemoteSources(playerManager,
-                      com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager .class);
+AudioSourceManagers.registerRemoteSources(playerManager,
+                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
 ```
 
 Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
-
 ```java
 AudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
-playerManager.
-
-registerSourceManager(ytSourceManager);
+playerManager.registerSourceManager(ytSourceManager);
 ```
 
 In addition, there are a few significant changes to note:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ explicitly excluded.
 First, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
+YoutubeAudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
 playerManager.registerSourceManager(ytSourceManager);
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releas
 By default, Lavaplayer instantiates and registers an instance of this deprecated `YoutubeAudioSourceManager` unless 
 explicitly excluded.
 
-Firstly, leverage the `excludeSources` parameter to prevent its instantiation during remote source registration.
+To avoid this unwanted instantiation, leverage the `excludeSources` parameter during remote source registration.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
 AudioSourceManagers.registerRemoteSources(playerManager,

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ however, it will continue to instantiate and register an instance unless otherwi
 Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of the deprecated `YoutubeAudioSourceManager` class.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManagers.registerRemoteSources(playerManager,
-                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
+AudioSourceManagers.registerRemoteSources(
+        playerManager, com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class
+);
 ```
 
 Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.

--- a/README.md
+++ b/README.md
@@ -177,20 +177,29 @@ Currently, the following clients are available for use:
     client enabled, age-restricted tracks are **not** guaranteed to play.
 
 ## Migration from Lavaplayer's built-in YouTube source
-This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer will continue to instantiate and register an instance of this deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
-Therefore, you may leverage the `excludeSources` parameter to prevent its instantiation.
+This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
+deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
+By default, Lavaplayer will continue to instantiate and register an instance of this
+deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
+
+Firstly, leverage the `excludeSources` parameter to prevent its instantiation.
+
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManagers.registerRemoteSources(playerManager,
-                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
+AudioSourceManagers.
+
+registerRemoteSources(playerManager,
+                      com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager .class);
 ```
 
 Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
+
 ```java
 AudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
-playerManager.registerSourceManager(ytSourceManager);
+playerManager.
+
+registerSourceManager(ytSourceManager);
 ```
 
 In addition, there are a few significant changes to note:

--- a/README.md
+++ b/README.md
@@ -178,15 +178,13 @@ Currently, the following clients are available for use:
 
 ## Migration from Lavaplayer's built-in YouTube source
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`. Lavaplayer deprecated this class in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2); 
-however, it will continue to instantiate and register an instance unless otherwise specified.
+however, it will continue to instantiate and register an instance unless explicitly excluded.
 
 Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of the deprecated `YoutubeAudioSourceManager` class.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
-AudioSourceManagers.registerRemoteSources(
-        playerManager, 
-        com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class
-);
+AudioSourceManagers.registerRemoteSources(playerManager,
+                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
 ```
 
 Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.

--- a/README.md
+++ b/README.md
@@ -180,8 +180,7 @@ Currently, the following clients are available for use:
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
 deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer will continue to instantiate and register an instance of its
-deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
+By default, Lavaplayer instantiates and registers a deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
 Firstly, leverage the `excludeSources` parameter to prevent its instantiation during remote source registration.
 ```java

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Currently, the following clients are available for use:
 
 ## Migration from Lavaplayer's built-in YouTube source
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-However, Lavaplayer will continue to instantiate and register an instance of this deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
+By default, Lavaplayer will continue to instantiate and register an instance of this deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
 Therefore, you may leverage the `excludeSources` parameter to prevent its instantiation.
 ```java

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Currently, the following clients are available for use:
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
 deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer instantiates and registers an instance of this deprecated `YoutubeAudioSourceManager` unless 
+By default, Lavaplayer instantiates and registers an instance of its deprecated `YoutubeAudioSourceManager` unless 
 explicitly excluded.
 
 To avoid this unwanted instantiation, leverage the `excludeSources` parameter during remote source registration.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Currently, the following clients are available for use:
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
 deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer instantiates and registers a deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
+By default, Lavaplayer instantiates and registers an instance of this deprecated `YoutubeAudioSourceManager` unless 
+explicitly excluded.
 
 Firstly, leverage the `excludeSources` parameter to prevent its instantiation during remote source registration.
 ```java

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ Currently, the following clients are available for use:
 
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers
 deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-By default, Lavaplayer will continue to instantiate and register an instance of this
+By default, Lavaplayer will continue to instantiate and register an instance of its
 deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
-Firstly, leverage the `excludeSources` parameter to prevent its instantiation.
+Firstly, leverage the `excludeSources` parameter to prevent its instantiation during remote source registration.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
 AudioSourceManagers.registerRemoteSources(playerManager,

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Currently, the following clients are available for use:
 
 ## Migration from Lavaplayer's built-in YouTube source
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-However, Lavaplayer will continue to instantiate and register an instance of this class unless explicitly excluded.
+However, Lavaplayer will continue to instantiate and register an instance of this deprecated class unless explicitly excluded.
 
 Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of this deprecated `YoutubeAudioSourceManager` class.
 ```java

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Currently, the following clients are available for use:
 
 ## Migration from Lavaplayer's built-in YouTube source
 This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`, which the maintainers deprecated in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2).
-However, Lavaplayer will continue to instantiate and register an instance of this deprecated class unless explicitly excluded.
+However, Lavaplayer will continue to instantiate and register an instance of this deprecated `YoutubeAudioSourceManager` unless explicitly excluded.
 
-Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of this deprecated `YoutubeAudioSourceManager` class.
+Therefore, you may leverage the `excludeSources` parameter to prevent its instantiation.
 ```java
 AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
 AudioSourceManagers.registerRemoteSources(playerManager,

--- a/README.md
+++ b/README.md
@@ -177,7 +177,23 @@ Currently, the following clients are available for use:
     client enabled, age-restricted tracks are **not** guaranteed to play.
 
 ## Migration from Lavaplayer's built-in YouTube source
-This client is intended to be a drop-in replacement, however there are a couple of things to note:
+This client is intended as a direct replacement for Lavaplayer's `YoutubeAudioSourceManager`. Lavaplayer deprecated this class in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2); 
+however, it will continue to instantiate and register an instance unless otherwise specified.
+
+Therefore, you may leverage the `excludeSources` parameter to prevent instantiation of the deprecated `YoutubeAudioSourceManager` class.
+```java
+AudioPlayerManager playerManager = new DefaultAudioPlayerManager();
+AudioSourceManagers.registerRemoteSources(playerManager,
+                                          com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager.class);
+```
+
+Then, create and register an instance of the supported `YoutubeAudioSourceManager` from the `youtube-source` package.
+```java
+AudioSourceManager ytSourceManager = new dev.lavalink.youtube.YoutubeAudioSourceManager();
+playerManager.registerSourceManager(ytSourceManager);
+```
+
+In addition, there are a few significant changes to note:
 
 - This source's class structure differs so if you had custom classes that you were initialising
   the source manager with (e.g. an overridden `YoutubeTrackDetailsLoader`), this **is not** compatible


### PR DESCRIPTION
**Type of Change**
Documentation Update

**Description**
I wanted to introduce some more context into migration from the deprecated `YoutubeAudioSourceManager` in the Lavaplayer repository. It may not be clear to developers that this class is still being instantiated by default, and that it should be excluded.

This is related to changes made to Lavaplayer in release [2.1.2](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2)

The following image demonstrates what happens when the supported `YoutubeAudioSourceManager` is registered without excluding the deprecated client. There are now two instances of the client, which could lead to unexpected behavior.

![image](https://github.com/lavalink-devs/youtube-source/assets/24926038/cb9910b5-8402-4d97-809c-ddfc735d8cca)


