### PR TITLE
Support OAuth2 Account Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Support for IP rotation has been included, and can be achieved using the followi
 AbstractRoutePlanner routePlanner = new ...
 YoutubeIpRotatorSetup rotator = new YoutubeIpRotatorSetup(routePlanner);
 
+// 'youtube' is the variable holding your YoutubeAudioSourceManager instance.
 rotator.forConfiguration(youtube.getHttpInterfaceManager(), false)
-    .withMainDelegateFilter(null) // This is important, otherwise you may get NullPointerExceptions.
+    .withMainDelegateFilter(youtube.getContextFilter()) // IMPORTANT
     .setup();
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Which clients are used is entirely configurable.
   - Information about the `plugin` module and usage of.
 - [Available Clients](#available-clients)
   - Information about the clients provided by `youtube-source`, as well as their advantages/disadvantages.
+- [Using OAuth tokens](#using-oauth-tokens)
+  - Information on using OAuth tokens with `youtube-source`.
 - [Using a poToken](#using-a-potoken)
   - Information on using a `poToken` with `youtube-source`.
 - [Migration Information](#migration-from-lavaplayers-built-in-youtube-source)
@@ -206,6 +208,52 @@ Currently, the following clients are available for use:
   - ✔ Opus formats.
   - ✔ Age-restricted video playback.
   - ❌ No playlist support.
+
+## Using OAuth Tokens
+You may notice that some requests are flagged by YouTube, causing an error message asking you to sign in to confirm you're not a bot.
+With OAuth integration, you can request that `youtube-source` use your account credentials to appear as a normal user, with varying degrees
+of efficacy. You can instruct `youtube-source` to use OAuth with the following:
+
+> [!WARNING]
+> Similar to the `poToken` method, this is NOT a silver bullet solution, and worst case could get your account terminated!
+> For this reason, it is advised that **you use burner accounts and NOT your primary!**.
+> This method may also trigger ratelimit errors if used in a high traffic environment.
+> USE WITH CAUTION!
+
+### Lavaplayer
+```java
+YoutubeAudioSourceManager source = new YoutubeAudioSourceManager();
+// This will trigger an OAuth flow, where you will be instructed to head to YouTube's OAuth page and input a code.
+// This is safe, as it only uses YouTube's official OAuth flow. No tokens are seen or stored by us.
+source.useOauth2(null, false);
+
+// If you already have a refresh token, you can instruct the source to use it, skipping the OAuth flow entirely.
+// You can also set the `skipInitialization` parameter, which skips the OAuth flow. This should only be used
+// if you intend to supply a refresh token later on. You **must** either complete the OAuth flow or supply
+// a refresh token for OAuth integration to work.
+source.useOauth2("your refresh token", true);
+```
+
+<!-- TODO document rest routes -->
+
+### Lavalink
+```yaml
+plugins:
+  youtube:
+    enabled: true
+    oauthConfig:
+      # setting "enabled: true" is the bare minimum to get OAuth working.
+      enabled: true
+
+      # you may optionally set your refresh token if you have one, which skips the OAuth flow entirely.
+      # once you have completed the oauth flow at least once, you should see your refresh token within your
+      # lavalink logs, which can be used here.
+      refreshToken: "your refresh token, only supply this if you have one!"
+
+      # Set this if you don't want the OAuth flow to be triggered, if you intend to supply a refresh token
+      # later on via REST routes. Initialization is skipped automatically if a valid refresh token is supplied.
+      skipInitialization: true
+```
 
 ## Using a `poToken`
 A `poToken`, also known as a "Proof of Origin Token" is a way to identify what requests originate from.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ source.useOauth2("your refresh token", true);
 plugins:
   youtube:
     enabled: true
-    oauthConfig:
+    oauth:
       # setting "enabled: true" is the bare minimum to get OAuth working.
       enabled: true
 

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -164,9 +164,12 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
      * Providing a refresh token will likely skip having to authenticate your account prior to making requests,
      * as long as the provided token is still valid.
      * @param refreshToken The token to use for generating access tokens. Can be null.
+     * @param skipInitialization Whether linking of an account should be skipped, if you intend to provide a
+     *                           refresh token later. This only applies on null/empty/invalid refresh tokens.
+     *                           Valid refresh tokens will not be presented with an initialization prompt.
      */
-    public void useOauth2(@Nullable String refreshToken) {
-        oauth2Handler.setRefreshToken(refreshToken);
+    public void useOauth2(@Nullable String refreshToken, boolean skipInitialization) {
+        oauth2Handler.setRefreshToken(refreshToken, skipInitialization);
     }
 
     @Nullable

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -65,6 +65,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
     protected final boolean allowDirectPlaylistIds;
     protected final Client[] clients;
 
+    protected YoutubeHttpContextFilter contextFilter;
     protected YoutubeOauth2Handler oauth2Handler;
     protected SignatureCipherManager cipherManager;
 
@@ -139,7 +140,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
 
         this.oauth2Handler = new YoutubeOauth2Handler(httpInterfaceManager);
 
-        YoutubeHttpContextFilter contextFilter = new YoutubeHttpContextFilter();
+        contextFilter = new YoutubeHttpContextFilter();
         contextFilter.setTokenTracker(new YoutubeAccessTokenTracker(httpInterfaceManager));
         contextFilter.setOauth2Handler(oauth2Handler);
 
@@ -368,6 +369,11 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
     @NotNull
     public Client[] getClients() {
         return clients;
+    }
+
+    @NotNull
+    public YoutubeHttpContextFilter getContextFilter() {
+        return contextFilter;
     }
 
     @NotNull

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -137,7 +137,6 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
         this.allowDirectPlaylistIds = options.isAllowDirectPlaylistIds();
         this.clients = clients;
         this.cipherManager = new SignatureCipherManager();
-
         this.oauth2Handler = new YoutubeOauth2Handler(httpInterfaceManager);
 
         contextFilter = new YoutubeHttpContextFilter();
@@ -377,6 +376,11 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
     @NotNull
     public YoutubeHttpContextFilter getContextFilter() {
         return contextFilter;
+    }
+
+    @NotNull
+    public YoutubeOauth2Handler getOauth2Handler() {
+        return oauth2Handler;
     }
 
     @NotNull

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -18,6 +18,7 @@ import dev.lavalink.youtube.clients.*;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import dev.lavalink.youtube.http.YoutubeAccessTokenTracker;
 import dev.lavalink.youtube.http.YoutubeHttpContextFilter;
+import dev.lavalink.youtube.http.YoutubeOauth2Handler;
 import dev.lavalink.youtube.track.YoutubeAudioTrack;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -58,12 +59,14 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
     private static final Pattern shortHandPattern = Pattern.compile("^" + PROTOCOL_REGEX + "(?:" + DOMAIN_REGEX + "/(?:live|embed|shorts)|" + SHORT_DOMAIN_REGEX + ")/(?<videoId>.*)");
 
     protected final HttpInterfaceManager httpInterfaceManager;
+
     protected final boolean allowSearch;
     protected final boolean allowDirectVideoIds;
     protected final boolean allowDirectPlaylistIds;
     protected final Client[] clients;
 
-    protected final SignatureCipherManager cipherManager;
+    protected YoutubeOauth2Handler oauth2Handler;
+    protected SignatureCipherManager cipherManager;
 
     public YoutubeAudioSourceManager() {
         this(true);
@@ -134,10 +137,13 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
         this.clients = clients;
         this.cipherManager = new SignatureCipherManager();
 
-        YoutubeAccessTokenTracker tokenTracker = new YoutubeAccessTokenTracker(httpInterfaceManager);
-        YoutubeHttpContextFilter youtubeHttpContextFilter = new YoutubeHttpContextFilter();
-        youtubeHttpContextFilter.setTokenTracker(tokenTracker);
-        httpInterfaceManager.setHttpContextFilter(youtubeHttpContextFilter);
+        this.oauth2Handler = new YoutubeOauth2Handler(httpInterfaceManager);
+
+        YoutubeHttpContextFilter contextFilter = new YoutubeHttpContextFilter();
+        contextFilter.setTokenTracker(new YoutubeAccessTokenTracker(httpInterfaceManager));
+        contextFilter.setOauth2Handler(oauth2Handler);
+
+        httpInterfaceManager.setHttpContextFilter(contextFilter);
     }
 
     @Override
@@ -149,6 +155,22 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
         for (Client client : clients) {
             client.setPlaylistPageCount(count);
         }
+    }
+
+    /**
+     * Instructs this source to use Oauth2 integration.
+     * {@code null} is valid and will kickstart the oauth process.
+     * Providing a refresh token will likely skip having to authenticate your account prior to making requests,
+     * as long as the provided token is still valid.
+     * @param refreshToken The token to use for generating access tokens. Can be null.
+     */
+    public void useOauth2(@Nullable String refreshToken) {
+        oauth2Handler.setRefreshToken(refreshToken);
+    }
+
+    @Nullable
+    public String getOauth2RefreshToken() {
+        return oauth2Handler.getRefreshToken();
     }
 
     @Override

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeAccessTokenTracker.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeAccessTokenTracker.java
@@ -4,6 +4,7 @@ import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
+import dev.lavalink.youtube.clients.Android;
 import dev.lavalink.youtube.clients.ClientConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -69,16 +70,10 @@ public class YoutubeAccessTokenTracker {
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       httpInterface.getContext().setAttribute(TOKEN_FETCH_CONTEXT_ATTRIBUTE, true);
 
-      ClientConfig clientConfig = new ClientConfig()
-          .withUserAgent("com.google.android.youtube/19.07.39 (Linux; U; Android 11) gzip")
-          .withClientName("ANDROID")
-          .withClientField("clientVersion", "19.07.39")
-          .withClientField("androidSdkVersion", 30)
-          .withUserField("lockedSafetyMode", false)
-          .setAttributes(httpInterface);
+      ClientConfig client = Android.BASE_CONFIG.setAttributes(httpInterface);
 
       HttpPost visitorIdPost = new HttpPost("https://youtubei.googleapis.com/youtubei/v1/visitor_id");
-      visitorIdPost.setEntity(new StringEntity(clientConfig.toJsonString(), "UTF-8"));
+      visitorIdPost.setEntity(new StringEntity(client.toJsonString(), "UTF-8"));
 
       try (CloseableHttpResponse response = httpInterface.execute(visitorIdPost)) {
         HttpClientTools.assertSuccessWithContent(response, "youtube visitor id");

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
@@ -68,17 +68,19 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     String userAgent = context.getAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED, String.class);
 
-    if (userAgent != null) {
-      request.setHeader("User-Agent", userAgent);
+    if (!request.getURI().getHost().contains("googlevideo")) {
+      if (userAgent != null) {
+        request.setHeader("User-Agent", userAgent);
 
-      String visitorData = context.getAttribute(ATTRIBUTE_VISITOR_DATA_SPECIFIED, String.class);
-      request.setHeader("X-Goog-Visitor-Id", visitorData != null ? visitorData : tokenTracker.getVisitorId());
+        String visitorData = context.getAttribute(ATTRIBUTE_VISITOR_DATA_SPECIFIED, String.class);
+        request.setHeader("X-Goog-Visitor-Id", visitorData != null ? visitorData : tokenTracker.getVisitorId());
 
-      context.removeAttribute(ATTRIBUTE_VISITOR_DATA_SPECIFIED);
-      context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
+        context.removeAttribute(ATTRIBUTE_VISITOR_DATA_SPECIFIED);
+        context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
+      }
+
+      oauth2Handler.applyToken(request);
     }
-
-    oauth2Handler.applyToken(request);
 
 //    try {
 //      URI uri = new URIBuilder(request.getURI())

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
@@ -24,9 +24,14 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
   private static final HttpContextRetryCounter retryCounter = new HttpContextRetryCounter("yt-token-retry");
 
   private YoutubeAccessTokenTracker tokenTracker;
+  private YoutubeOauth2Handler oauth2Handler;
 
   public void setTokenTracker(@NotNull YoutubeAccessTokenTracker tokenTracker) {
     this.tokenTracker = tokenTracker;
+  }
+
+  public void setOauth2Handler(@NotNull YoutubeOauth2Handler oauth2Handler) {
+    this.oauth2Handler = oauth2Handler;
   }
 
   @Override
@@ -57,6 +62,10 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
       return;
     }
 
+    if (oauth2Handler.isOauthFetchContext(context)) {
+      return;
+    }
+
     String userAgent = context.getAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED, String.class);
 
     if (userAgent != null) {
@@ -68,6 +77,8 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
       context.removeAttribute(ATTRIBUTE_VISITOR_DATA_SPECIFIED);
       context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
     }
+
+    oauth2Handler.applyToken(request);
 
 //    try {
 //      URI uri = new URIBuilder(request.getURI())

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -48,13 +48,14 @@ public class YoutubeOauth2Handler {
         this.httpInterfaceManager = httpInterfaceManager;
     }
 
-    public void setRefreshToken(@Nullable String refreshToken) {
+    public void setRefreshToken(@Nullable String refreshToken, boolean skipInitialization) {
         this.refreshToken = refreshToken;
         this.tokenExpires = System.currentTimeMillis(); // to trigger an access token refresh
 
         // TODO: need to check what error is returned for invalid refresh tokens and fall back to
         //       initialization if invalid.
-        if (DataFormatTools.isNullOrEmpty(refreshToken)) {
+        // TODO: Check token validity?
+        if (DataFormatTools.isNullOrEmpty(refreshToken) && !skipInitialization) {
             initializeAccessToken();
         }
     }

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -1,0 +1,207 @@
+package dev.lavalink.youtube.http;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+import com.grack.nanojson.JsonWriter;
+import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+public class YoutubeOauth2Handler {
+    private static final Logger log = LoggerFactory.getLogger(YoutubeAccessTokenTracker.class);
+    private static int fetchErrorLogCount = 0;
+
+    // no, i haven't leaked anything of mine
+    // this (i presume) can be found within youtube's page source
+    // ¯\_(ツ)_/¯
+    private static final String CLIENT_ID = "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com";
+    private static final String CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT";
+    private static final String SCOPES = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube";
+    private static final String OAUTH_FETCH_CONTEXT_ATTRIBUTE = "yt-oauth";
+
+    private final HttpInterfaceManager httpInterfaceManager;
+
+    private boolean enabled;
+    private String refreshToken;
+
+    private String tokenType;
+    private String accessToken;
+    private long tokenExpires;
+
+    public YoutubeOauth2Handler(HttpInterfaceManager httpInterfaceManager) {
+        this.httpInterfaceManager = httpInterfaceManager;
+    }
+
+    public void setRefreshToken(@Nullable String refreshToken) {
+        this.refreshToken = refreshToken;
+        this.tokenExpires = System.currentTimeMillis(); // to trigger an access token refresh
+
+        if (refreshToken == null) {
+            initializeAccessToken();
+        }
+    }
+
+    @Nullable
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public boolean isOauthFetchContext(HttpClientContext context) {
+        return context.getAttribute(OAUTH_FETCH_CONTEXT_ATTRIBUTE) == Boolean.TRUE;
+    }
+
+    /**
+     * Makes a request to YouTube for a device code that users can then authorise to allow
+     * this source to make requests using an account access token.
+     * This will begin the oauth flow. If a refresh token is present, {@link #refreshAccessToken()} should
+     * be used instead.
+     */
+    private void initializeAccessToken() {
+        JsonObject response = fetchDeviceCode();
+        String verificationUrl = response.getString("verification_url");
+        String userCode = response.getString("user_code");
+        String deviceCode = response.getString("device_code");
+
+        log.info("==================================================");
+        log.info("!!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!");
+        log.info("OAUTH INTEGRATION: To give youtube-source access to your account, go to {} and enter code {}", verificationUrl, userCode);
+        log.info("!!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!");
+        log.info("==================================================");
+
+        // Should this be a daemon?
+        new Thread(() -> pollForToken(deviceCode), "youtube-source-token-poller").start();
+    }
+
+    private JsonObject fetchDeviceCode() {
+        // @formatter:off
+        String requestJson = JsonWriter.string()
+            .object()
+                .value("client_id", CLIENT_ID)
+                .value("scope", SCOPES)
+                .value("device_id", UUID.randomUUID().toString().replace("-", ""))
+                .value("device_model", "ytlr::")
+            .end()
+            .done();
+        // @formatter:on
+
+        HttpPost request = new HttpPost("https://www.youtube.com/o/oauth2/device/code");
+        StringEntity body = new StringEntity(requestJson, ContentType.APPLICATION_JSON);
+        request.setEntity(body);
+
+        try (HttpInterface httpInterface = getHttpInterface();
+             CloseableHttpResponse response = httpInterface.execute(request)) {
+            HttpClientTools.assertSuccessWithContent(response, "device code fetch");
+            return JsonParser.object().from(response.getEntity().getContent());
+        } catch (IOException | JsonParserException e) {
+            throw ExceptionTools.toRuntimeException(e);
+        }
+    }
+
+    private void pollForToken(String deviceCode) {
+        // @formatter:off
+        String requestJson = JsonWriter.string()
+            .object()
+                .value("client_id", CLIENT_ID)
+                .value("client_secret", CLIENT_SECRET)
+                .value("code", deviceCode)
+                .value("grant_type", "http://oauth.net/grant_type/device/1.0")
+            .end()
+            .done();
+        // @formatter:on
+
+        HttpPost request = new HttpPost("https://www.youtube.com/o/oauth2/token");
+        StringEntity body = new StringEntity(requestJson, ContentType.APPLICATION_JSON);
+        request.setEntity(body);
+
+        while (true) {
+            try (HttpInterface httpInterface = getHttpInterface();
+                 CloseableHttpResponse response = httpInterface.execute(request)) {
+                HttpClientTools.assertSuccessWithContent(response, "oauth2 token fetch");
+                JsonObject parsed = JsonParser.object().from(response.getEntity().getContent());
+
+                if (parsed.has("error") && !parsed.isNull("error")) {
+                    String error = parsed.getString("error");
+
+                    if (error.equals("authorization_pending")) {
+                        long interval = parsed.getLong("interval");
+                        Thread.sleep(Math.max(5000, interval * 1000));
+                        continue;
+                    } else if (error.equals("expired_token")) {
+                        log.error("OAUTH INTEGRATION: The device token has expired. OAuth integration has been canceled.");
+                    } else {
+                        log.error("Unhandled OAuth2 error: {}", error);
+                    }
+
+                    return;
+                }
+
+                tokenType = parsed.getString("token_type");
+                accessToken = parsed.getString("access_token");
+                refreshToken = parsed.getString("refresh_token");
+                tokenExpires = System.currentTimeMillis() + (parsed.getLong("expires_in") * 1000) - 60000;
+                log.info("OAUTH INTEGRATION: Token retrieved successfully. Access Token: {}, Refresh Token: {}", accessToken, refreshToken);
+
+                enabled = true;
+                return;
+            } catch (IOException | JsonParserException | InterruptedException e) {
+                log.error("Failed to fetch OAuth2 token response", e);
+            }
+        }
+    }
+
+    private void refreshAccessToken() {
+        // SUBTRACT 1 MINUTE FROM TOKEN EXPIRY
+    }
+
+    public void applyToken(HttpUriRequest request) {
+        if (!enabled || refreshToken == null) {
+            return;
+        }
+
+        if (System.currentTimeMillis() > tokenExpires) {
+            try {
+                refreshAccessToken();
+            } catch (Throwable t) {
+                if (fetchErrorLogCount++ <= 3) {
+                    // log fetch errors up to 3 times to avoid spamming logs.
+                    // in theory, we can still make requests without an access token,
+                    // it's just less likely to succeed, but we shouldn't bloat a user's logs
+                    // in the event YT changes something and breaks oauth integration.
+                    // anyway, the chances of each error being different is small i think.
+                    log.error("Refreshing YouTube access token failed", t);
+                }
+
+                // retry in 15 seconds to avoid spamming YouTube with requests.
+                tokenExpires = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(15);
+                return;
+            }
+        }
+
+        // check again to ensure updating worked as expected.
+        if (accessToken != null && tokenType != null && System.currentTimeMillis() + 60000 < tokenExpires) {
+            request.setHeader("Authorization", String.format("%s %s", tokenType, accessToken));
+        }
+    }
+
+    private HttpInterface getHttpInterface() {
+        HttpInterface httpInterface = httpInterfaceManager.getInterface();
+        httpInterface.getContext().setAttribute(OAUTH_FETCH_CONTEXT_ATTRIBUTE, true);
+        return httpInterface;
+    }
+}

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -4,6 +4,7 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 import com.grack.nanojson.JsonWriter;
+import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
@@ -14,7 +15,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,9 @@ public class YoutubeOauth2Handler {
         this.refreshToken = refreshToken;
         this.tokenExpires = System.currentTimeMillis(); // to trigger an access token refresh
 
-        if (refreshToken == null) {
+        // TODO: need to check what error is returned for invalid refresh tokens and fall back to
+        //       initialization if invalid.
+        if (DataFormatTools.isNullOrEmpty(refreshToken)) {
             initializeAccessToken();
         }
     }
@@ -173,8 +175,8 @@ public class YoutubeOauth2Handler {
     }
 
     private void refreshAccessToken() {
-        if (refreshToken == null) {
-            throw new IllegalStateException("Cannot refresh access token without a refresh token!");
+        if (DataFormatTools.isNullOrEmpty(refreshToken)) {
+            throw new IllegalStateException("Cannot fetch access token without a refresh token!");
         }
 
         // @formatter:off
@@ -214,7 +216,7 @@ public class YoutubeOauth2Handler {
     }
 
     public void applyToken(HttpUriRequest request) {
-        if (!enabled || refreshToken == null) {
+        if (!enabled || DataFormatTools.isNullOrEmpty(refreshToken)) {
             return;
         }
 

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class YoutubeOauth2Handler {
-    private static final Logger log = LoggerFactory.getLogger(YoutubeAccessTokenTracker.class);
+    private static final Logger log = LoggerFactory.getLogger(YoutubeOauth2Handler.class);
     private static int fetchErrorLogCount = 0;
 
     // no, i haven't leaked anything of mine

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -51,9 +51,8 @@ public class YoutubeOauth2Handler {
     public void setRefreshToken(@Nullable String refreshToken, boolean skipInitialization) {
         this.refreshToken = refreshToken;
         this.tokenExpires = System.currentTimeMillis();
+        this.accessToken = null;
 
-        // TODO: need to check what error is returned for invalid refresh tokens and fall back to
-        //       initialization if invalid.
         if (!DataFormatTools.isNullOrEmpty(refreshToken)) {
             refreshAccessToken(true);
 

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -59,6 +59,8 @@ public class YoutubeOauth2Handler {
 
             // if refreshAccessToken() fails, enabled will never be flipped, so we don't use
             // oauth tokens erroneously.
+            // TODO?: This should fall back to access token initialization if refresh isn't valid,
+            //        provided "skipInitialization" is not true.
             enabled = true;
         } else if (!skipInitialization) {
             initializeAccessToken();

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
@@ -17,9 +17,7 @@ public class YoutubeConfig {
     private Pot pot = null;
     private String[] clients;
     private Map<String, ClientOptions> clientOptions = new HashMap<>();
-
-    private boolean useOauth2 = false;
-    private String oauth2RefreshToken = null;
+    private YoutubeOauthConfig oauthConfig = null;
 
     public boolean getEnabled() {
         return enabled;
@@ -49,12 +47,8 @@ public class YoutubeConfig {
         return clientOptions;
     }
 
-    public boolean getUseOauth2() {
-        return this.useOauth2;
-    }
-
-    public String getOauth2RefreshToken() {
-        return this.oauth2RefreshToken;
+    public YoutubeOauthConfig getOauthConfig() {
+        return this.oauthConfig;
     }
 
     public void setEnabled(boolean enabled) {
@@ -85,11 +79,7 @@ public class YoutubeConfig {
         this.clientOptions = clientOptions;
     }
 
-    public void setUseOauth2(boolean useOauth2) {
-        this.useOauth2 = useOauth2;
-    }
-
-    public void setOauth2RefreshToken(String oauth2RefreshToken) {
-        this.oauth2RefreshToken = oauth2RefreshToken;
+    public void setOauthConfig(YoutubeOauthConfig oauthConfig) {
+        this.oauthConfig = oauthConfig;
     }
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
@@ -17,7 +17,7 @@ public class YoutubeConfig {
     private Pot pot = null;
     private String[] clients;
     private Map<String, ClientOptions> clientOptions = new HashMap<>();
-    private YoutubeOauthConfig oauthConfig = null;
+    private YoutubeOauthConfig oauth = null;
 
     public boolean getEnabled() {
         return enabled;
@@ -47,8 +47,8 @@ public class YoutubeConfig {
         return clientOptions;
     }
 
-    public YoutubeOauthConfig getOauthConfig() {
-        return this.oauthConfig;
+    public YoutubeOauthConfig getOauth() {
+        return this.oauth;
     }
 
     public void setEnabled(boolean enabled) {
@@ -79,7 +79,7 @@ public class YoutubeConfig {
         this.clientOptions = clientOptions;
     }
 
-    public void setOauthConfig(YoutubeOauthConfig oauthConfig) {
-        this.oauthConfig = oauthConfig;
+    public void setOauth(YoutubeOauthConfig oauth) {
+        this.oauth = oauth;
     }
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
@@ -18,6 +18,9 @@ public class YoutubeConfig {
     private String[] clients;
     private Map<String, ClientOptions> clientOptions = new HashMap<>();
 
+    private boolean useOauth2 = false;
+    private String oauth2RefreshToken = null;
+
     public boolean getEnabled() {
         return enabled;
     }
@@ -46,6 +49,14 @@ public class YoutubeConfig {
         return clientOptions;
     }
 
+    public boolean getUseOauth2() {
+        return this.useOauth2;
+    }
+
+    public String getOauth2RefreshToken() {
+        return this.oauth2RefreshToken;
+    }
+
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
@@ -72,5 +83,13 @@ public class YoutubeConfig {
 
     public void setClientOptions(Map<String, ClientOptions> clientOptions) {
         this.clientOptions = clientOptions;
+    }
+
+    public void setUseOauth2(boolean useOauth2) {
+        this.useOauth2 = useOauth2;
+    }
+
+    public void setOauth2RefreshToken(String oauth2RefreshToken) {
+        this.oauth2RefreshToken = oauth2RefreshToken;
     }
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeOauthConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeOauthConfig.java
@@ -1,9 +1,31 @@
 package dev.lavalink.youtube.plugin;
 
 public class YoutubeOauthConfig {
+    private boolean enabled = false;
     private String refreshToken;
+    private boolean skipInitialization = false;
+
+    public boolean getEnabled() {
+        return enabled;
+    }
 
     public String getRefreshToken() {
         return refreshToken;
+    }
+
+    public boolean getSkipInitialization() {
+        return skipInitialization;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setSkipInitialization(boolean skipInitialization) {
+        this.skipInitialization = skipInitialization;
     }
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeOauthConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeOauthConfig.java
@@ -1,0 +1,9 @@
+package dev.lavalink.youtube.plugin;
+
+public class YoutubeOauthConfig {
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+}

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -204,6 +204,12 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             source.setPlaylistPageCount(playlistLoadLimit);
         }
 
+        if (youtubeConfig != null) {
+            if (youtubeConfig.getUseOauth2()) {
+                source.useOauth2(youtubeConfig.getOauth2RefreshToken());
+            }
+        }
+
         audioPlayerManager.registerSourceManager(source);
         return audioPlayerManager;
     }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -187,7 +187,7 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             final int retryLimit = ratelimitConfig.getRetryLimit();
             final YoutubeIpRotatorSetup rotator = new YoutubeIpRotatorSetup(routePlanner)
                 .forConfiguration(source.getHttpInterfaceManager(), false)
-                .withMainDelegateFilter(null); // Necessary to avoid NPEs.
+                .withMainDelegateFilter(source.getContextFilter());
 
             if (retryLimit == 0) {
                 rotator.withRetryLimit(Integer.MAX_VALUE);

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -204,9 +204,11 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             source.setPlaylistPageCount(playlistLoadLimit);
         }
 
-        if (youtubeConfig != null) {
-            if (youtubeConfig.getUseOauth2()) {
-                source.useOauth2(youtubeConfig.getOauth2RefreshToken());
+        if (youtubeConfig != null && youtubeConfig.getOauthConfig() != null) {
+            YoutubeOauthConfig oauthConfig = youtubeConfig.getOauthConfig();
+
+            if (oauthConfig.getEnabled()) {
+                source.useOauth2(oauthConfig.getRefreshToken(), oauthConfig.getSkipInitialization());
             }
         }
 

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -204,8 +204,8 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             source.setPlaylistPageCount(playlistLoadLimit);
         }
 
-        if (youtubeConfig != null && youtubeConfig.getOauthConfig() != null) {
-            YoutubeOauthConfig oauthConfig = youtubeConfig.getOauthConfig();
+        if (youtubeConfig != null && youtubeConfig.getOauth() != null) {
+            YoutubeOauthConfig oauthConfig = youtubeConfig.getOauth();
 
             if (oauthConfig.getEnabled()) {
                 log.debug("Configuring youtube oauth integration with token: \"{}\" skipInitialization: {}", oauthConfig.getRefreshToken(), oauthConfig.getSkipInitialization());

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -208,6 +208,7 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
             YoutubeOauthConfig oauthConfig = youtubeConfig.getOauthConfig();
 
             if (oauthConfig.getEnabled()) {
+                log.debug("Configuring youtube oauth integration with token: \"{}\" skipInitialization: {}", oauthConfig.getRefreshToken(), oauthConfig.getSkipInitialization());
                 source.useOauth2(oauthConfig.getRefreshToken(), oauthConfig.getSkipInitialization());
             }
         }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -1,0 +1,51 @@
+package dev.lavalink.youtube.plugin;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+public class YoutubeRestHandler {
+    private static final Logger log = LoggerFactory.getLogger(YoutubeRestHandler.class);
+
+    private final AudioPlayerManager playerManager;
+
+    public YoutubeRestHandler(AudioPlayerManager playerManager) {
+        this.playerManager = playerManager;
+    }
+
+    @GetMapping("/v4/youtube")
+    public Map<String, String> getYoutubeConfig() {
+        YoutubeAudioSourceManager source = playerManager.source(YoutubeAudioSourceManager.class);
+
+        if (source == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The YouTube source manager is not registered.");
+        }
+
+        return Collections.singletonMap("refreshToken", source.getOauth2RefreshToken());
+    }
+
+    @PostMapping("/v4/youtube")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateRefreshToken(@RequestBody YoutubeOauthConfig config) {
+        YoutubeAudioSourceManager source = playerManager.source(YoutubeAudioSourceManager.class);
+
+        if (source == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The YouTube source manager is not registered.");
+        }
+
+        source.useOauth2(config.getRefreshToken());
+        log.debug("Updated YouTube OAuth2 refresh token to {}", config.getRefreshToken());
+    }
+}

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -45,7 +45,7 @@ public class YoutubeRestHandler {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The YouTube source manager is not registered.");
         }
 
-        source.useOauth2(config.getRefreshToken());
+        source.useOauth2(config.getRefreshToken(), config.getSkipInitialization());
         log.debug("Updated YouTube OAuth2 refresh token to {}", config.getRefreshToken());
     }
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -48,6 +48,4 @@ public class YoutubeRestHandler {
         source.useOauth2(config.getRefreshToken(), config.getSkipInitialization());
         log.debug("Updated YouTube OAuth2 refresh token to {}", config.getRefreshToken());
     }
-
-
 }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -38,7 +38,7 @@ public class YoutubeRestHandler {
 
     @PostMapping("/v4/youtube")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateRefreshToken(@RequestBody YoutubeOauthConfig config) {
+    public void updateOauth(@RequestBody YoutubeOauthConfig config) {
         YoutubeAudioSourceManager source = playerManager.source(YoutubeAudioSourceManager.class);
 
         if (source == null) {
@@ -48,4 +48,6 @@ public class YoutubeRestHandler {
         source.useOauth2(config.getRefreshToken(), config.getSkipInitialization());
         log.debug("Updated YouTube OAuth2 refresh token to {}", config.getRefreshToken());
     }
+
+
 }


### PR DESCRIPTION
This PR implements support for linking accounts via OAuth2.

By acting as a TV client, we can request users input a code into the official device linking webpage which grants us an access token and a refresh token, which with the former, can be dispatched with requests effectively serving as a replacement to the original source manager's account authentication system. The entire process is done without any external hosted services so security is vastly improved, and this relies on the OAuth flow provided by YT/Google.

The downside to this system is it requires users to keep track of refresh tokens, or authorize youtube-source on every launch.
There are facilities provided to fetch and set refresh tokens to allow for some form of persistence.

This PR requires a few finer details to be worked out, notably:
- what happens if an invalid refresh token is provided? This should be handled gracefully, and begin the OAuth process anew.
- REST endpoints require testing.
- REST endpoints require some form of locking to avoid users making POST requests to update refresh tokens whilst an OAuth initialisation/refresh process is occurring.
- Documenting the new endpoints and config properties.

The basic functionality of this PR has been tested, and account authentication does work, with authorization headers being appended onto relevant requests. Testing has not been done to ensure the success of token refreshing as of yet. I also cannot confirm whether providing authentication alleviates any current issues such as "Sign in to confirm you're not a bot" or accessing age restricted videos that the embedded TV client does not provide access to.

A big, or rather, VERY BIG disclaimer to this PR is to use with caution. DO NOT use your main account(s).