### PR TITLE
Support specifying poToken for WEB client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Currently, the following clients are available for use:
   - ❌ No playlist support.
 
 ## Using a `poToken`
-First off, you'll need to obtain a `poToken`. This can be done using https://github.com/iv-org/youtube-trusted-session-generatorrun,
+First off, you'll need to obtain a `poToken`. This can be done using https://github.com/iv-org/youtube-trusted-session-generator,
 by running the Python script or the docker image. Both methods will print a `poToken` after a successful run,
 which you can supply to `youtube-source` to try and work around having automated requests blocked.
 Specifying the token is as simple as doing:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ Currently, the following clients are available for use:
   - ✔ Age-restricted video playback.
   - ❌ No playlist support.
 
+## Using a `poToken`
+First off, you'll need to obtain a `poToken`. This can be done using https://github.com/iv-org/youtube-trusted-session-generatorrun,
+by running the Python script or the docker image. Both methods will print a `poToken` after a successful run,
+which you can supply to `youtube-source` to try and work around having automated requests blocked.
+Specifying the token is as simple as doing:
+```yaml
+plugins:
+  youtube:
+    poToken: "paste your token here"
+```
+You do **not** need the `visitor_data` that is also produced by the script.
+
+> [!NOTE]
+> A `poToken` is not a silver bullet, and currently it only applies to requests made via the `WEB` client.
+> Currently, the most effective method for working around automated request blocking is to use IPv6 rotation.
+
 ## Migration from Lavaplayer's built-in YouTube source
 
 This client is intended as a direct replacement for Lavaplayer's built-in `YoutubeAudioSourceManager`,

--- a/README.md
+++ b/README.md
@@ -203,9 +203,10 @@ Specifying the token is as simple as doing:
 ```yaml
 plugins:
   youtube:
-    poToken: "paste your token here"
+    pot:
+      token: "paste your po_token here"
+      visitorData: "paste your visitor_data here"
 ```
-You do **not** need the `visitor_data` that is also produced by the script.
 
 > [!NOTE]
 > A `poToken` is not a silver bullet, and currently it only applies to requests made via the `WEB` client.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ You do **not** need the `visitor_data` that is also produced by the script.
 
 > [!NOTE]
 > A `poToken` is not a silver bullet, and currently it only applies to requests made via the `WEB` client.
-> Currently, the most effective method for working around automated request blocking is to use IPv6 rotation.
+> 
+> At the time of writing, the most effective method for working around automated request blocking is to use IPv6 rotation.
 
 ## Migration from Lavaplayer's built-in YouTube source
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,15 @@ Currently, the following clients are available for use:
   - ❌ No playlist support.
 
 ## Using a `poToken`
-First off, you'll need to obtain a `poToken`. This can be done using https://github.com/iv-org/youtube-trusted-session-generator,
-by running the Python script or the docker image. Both methods will print a `poToken` after a successful run,
-which you can supply to `youtube-source` to try and work around having automated requests blocked.
+A `poToken`, also known as a "Proof of Origin Token" is a way to identify what requests originate from.
+In YouTube's case, this is sent as a JavaScript challenge that browsers must evaluate, and send back the resolved
+string. Typically, this challenge would remain unsolved for bots as more often than not, they don't simulate an entire
+browser environment, instead only evaluating the minimum amount of JS required to do its job. Therefore, it's a reasonable
+assumption that if the challenge is not fulfilled, the request origin is a bot.
+
+To obtain a `poToken`, you can use https://github.com/iv-org/youtube-trusted-session-generator, by running the Python script
+or the docker image. Both methods will print a `poToken` after a successful run, which you can supply to `youtube-source`
+to try and work around having automated requests blocked.
 Specifying the token is as simple as doing:
 ```yaml
 plugins:

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeAudioSourceManager.java
@@ -116,10 +116,21 @@ public class YoutubeAudioSourceManager implements AudioSourceManager {
                                      boolean allowDirectVideoIds,
                                      boolean allowDirectPlaylistIds,
                                      @NotNull Client... clients) {
+        this(
+            new YoutubeSourceOptions()
+                .setAllowSearch(allowSearch)
+                .setAllowDirectVideoIds(allowDirectVideoIds)
+                .setAllowDirectPlaylistIds(allowDirectPlaylistIds),
+            clients
+        );
+    }
+
+    public YoutubeAudioSourceManager(YoutubeSourceOptions options,
+                                     @NotNull Client... clients) {
         this.httpInterfaceManager = HttpClientTools.createCookielessThreadLocalManager();
-        this.allowSearch = allowSearch;
-        this.allowDirectVideoIds = allowDirectVideoIds;
-        this.allowDirectPlaylistIds = allowDirectPlaylistIds;
+        this.allowSearch = options.isAllowSearch();
+        this.allowDirectVideoIds = options.isAllowDirectVideoIds();
+        this.allowDirectPlaylistIds = options.isAllowDirectPlaylistIds();
         this.clients = clients;
         this.cipherManager = new SignatureCipherManager();
 

--- a/common/src/main/java/dev/lavalink/youtube/YoutubeSourceOptions.java
+++ b/common/src/main/java/dev/lavalink/youtube/YoutubeSourceOptions.java
@@ -1,0 +1,34 @@
+package dev.lavalink.youtube;
+
+public class YoutubeSourceOptions {
+    private boolean allowSearch = true;
+    private boolean allowDirectVideoIds = true;
+    private boolean allowDirectPlaylistIds = true;
+
+    public boolean isAllowSearch() {
+        return allowSearch;
+    }
+
+    public boolean isAllowDirectVideoIds() {
+        return allowDirectVideoIds;
+    }
+
+    public boolean isAllowDirectPlaylistIds() {
+        return allowDirectPlaylistIds;
+    }
+
+    public YoutubeSourceOptions setAllowSearch(boolean allowSearch) {
+        this.allowSearch = allowSearch;
+        return this;
+    }
+
+    public YoutubeSourceOptions setAllowDirectVideoIds(boolean allowDirectVideoIds) {
+        this.allowDirectVideoIds = allowDirectVideoIds;
+        return this;
+    }
+
+    public YoutubeSourceOptions setAllowDirectPlaylistIds(boolean allowDirectPlaylistIds) {
+        this.allowDirectPlaylistIds = allowDirectPlaylistIds;
+        return this;
+    }
+}

--- a/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
@@ -38,6 +38,26 @@ public class ClientConfig {
         this.root = context;
     }
 
+    public String getName() {
+        return this.name;
+    }
+
+    public String getUserAgent() {
+        return this.userAgent;
+    }
+
+    public String getVisitorData() {
+        return this.visitorData;
+    }
+
+    public String getApiKey() {
+        return this.apiKey;
+    }
+
+    public Map<String, Object> getRoot() {
+        return this.root;
+    }
+
     public ClientConfig copy() {
         return new ClientConfig(new HashMap<>(this.root), this.userAgent, this.visitorData, this.name);
     }
@@ -48,17 +68,9 @@ public class ClientConfig {
         return this;
     }
 
-    public String getName() {
-        return this.name;
-    }
-
     public ClientConfig withUserAgent(@NotNull String userAgent) {
         this.userAgent = userAgent;
         return this;
-    }
-
-    public String getUserAgent() {
-        return this.userAgent;
     }
 
     public ClientConfig withVisitorData(@NotNull String visitorData) {
@@ -70,10 +82,6 @@ public class ClientConfig {
     public ClientConfig withApiKey(@NotNull String apiKey) {
         this.apiKey = apiKey;
         return this;
-    }
-
-    public String getApiKey() {
-        return this.apiKey;
     }
 
     public Map<String, Object> putOnceAndJoin(@NotNull Map<String, Object> on,

--- a/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
@@ -73,9 +73,31 @@ public class ClientConfig {
         return this;
     }
 
-    public ClientConfig withVisitorData(@NotNull String visitorData) {
+    public ClientConfig withVisitorData(@Nullable String visitorData) {
         this.visitorData = visitorData;
-        withClientField("visitorData", visitorData);
+
+        if (visitorData != null) {
+            withClientField("visitorData", visitorData);
+        } else {
+            Map<String, Object> context = (Map<String, Object>) root.get("context");
+
+            if (context != null) {
+                Map<String, Object> client = (Map<String, Object>) context.get("client");
+
+                if (client != null) {
+                    client.remove("visitorData");
+
+                    if (client.isEmpty()) {
+                        context.remove("client");
+                    }
+                }
+
+                if (context.isEmpty()) {
+                    root.remove("context");
+                }
+            }
+        }
+
         return this;
     }
 

--- a/common/src/main/java/dev/lavalink/youtube/clients/Web.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Web.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 public class Web extends StreamingNonMusicClient {
     private static final Logger log = LoggerFactory.getLogger(Web.class);
+
     protected static Pattern CONFIG_REGEX = Pattern.compile("ytcfg\\.set\\((\\{.+})\\);");
 
     public static ClientConfig BASE_CONFIG = new ClientConfig()
@@ -32,6 +33,8 @@ public class Web extends StreamingNonMusicClient {
         .withClientName("WEB")
         .withClientField("clientVersion", "2.20240224.11.00")
         .withUserField("lockedSafetyMode", false);
+
+    public static String poToken;
 
     protected volatile long lastConfigUpdate = -1;
 
@@ -46,6 +49,8 @@ public class Web extends StreamingNonMusicClient {
     }
 
     public static void setPoToken(String poToken) {
+        Web.poToken = poToken;
+
         if (poToken == null) {
             BASE_CONFIG.getRoot().remove("serviceIntegrityDimensions");
             return;

--- a/common/src/main/java/dev/lavalink/youtube/clients/Web.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Web.java
@@ -9,6 +9,7 @@ import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.clients.skeleton.StreamingNonMusicClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,6 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -130,6 +133,25 @@ public class Web extends StreamingNonMusicClient {
         }
 
         return BASE_CONFIG.copy();
+    }
+
+    @Override
+    @NotNull
+    public URI transformPlaybackUri(@NotNull URI originalUri, @NotNull URI resolvedPlaybackUri) {
+        if (poToken == null) {
+            return resolvedPlaybackUri;
+        }
+
+        log.debug("Applying 'pot' parameter on playback URI: {}", resolvedPlaybackUri);
+        URIBuilder builder = new URIBuilder(resolvedPlaybackUri);
+        builder.addParameter("pot", poToken);
+
+        try {
+            return builder.build();
+        } catch (URISyntaxException e) {
+            log.debug("Failed to apply 'pot' parameter.", e);
+            return resolvedPlaybackUri;
+        }
     }
 
     @Override

--- a/common/src/main/java/dev/lavalink/youtube/clients/Web.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Web.java
@@ -51,16 +51,18 @@ public class Web extends StreamingNonMusicClient {
         this.options = options;
     }
 
-    public static void setPoToken(String poToken) {
+    public static void setPoTokenAndVisitorData(String poToken, String visitorData) {
         Web.poToken = poToken;
 
-        if (poToken == null) {
+        if (poToken == null || visitorData == null) {
             BASE_CONFIG.getRoot().remove("serviceIntegrityDimensions");
+            BASE_CONFIG.withVisitorData(null);
             return;
         }
 
         Map<String, Object> sid = BASE_CONFIG.putOnceAndJoin(BASE_CONFIG.getRoot(), "serviceIntegrityDimensions");
         sid.put("poToken", poToken);
+        BASE_CONFIG.withVisitorData(visitorData);
     }
 
     protected void fetchClientConfig(@NotNull HttpInterface httpInterface) {
@@ -109,12 +111,11 @@ public class Web extends StreamingNonMusicClient {
                     BASE_CONFIG.withClientField("clientVersion", clientVersion);
                 }
 
-                String visitorData = client.get("visitorData").text();
-
-                if (visitorData != null && !visitorData.isEmpty() && BASE_CONFIG.getVisitorData() == null) {
-                    // don't overwrite if visitorData was already set.
-                    BASE_CONFIG.withVisitorData(visitorData);
-                }
+//                String visitorData = client.get("visitorData").text();
+//
+//                if (visitorData != null && !visitorData.isEmpty()) {
+//                    BASE_CONFIG.withVisitorData(visitorData);
+//                }
             }
         } catch (IOException e) {
             throw ExceptionTools.toRuntimeException(e);

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -131,6 +132,21 @@ public interface Client {
         }
 
         return null;
+    }
+
+    /**
+     * Transforms a given playback URL as necessary. For example, you can add query parameters
+     * or resolve any challenge parameters that might be needed.
+     * @param originalUri The original stream URI. This will be completely unmodified, and is
+     *                    provided as it has been received from YouTube.
+     * @param resolvedPlaybackUri The playback URI. This will have already been
+     *                            transformed by the SignatureCipherManager.
+     * @return The new playback URI.
+     */
+    @NotNull
+    default URI transformPlaybackUri(@NotNull URI originalUri,
+                                     @NotNull URI resolvedPlaybackUri) {
+        return resolvedPlaybackUri;
     }
 
     /**

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -15,11 +15,9 @@ import dev.lavalink.youtube.CannotBeLoaded;
 import dev.lavalink.youtube.UrlTools;
 import dev.lavalink.youtube.UrlTools.UrlInfo;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
-import dev.lavalink.youtube.clients.Web;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import dev.lavalink.youtube.track.format.StreamFormat;
 import dev.lavalink.youtube.track.format.TrackFormats;
-import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -190,17 +188,12 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     StreamFormat format = formats.getBestFormat();
 
-    URI signedUrl = sourceManager.getCipherManager()
+    URI resolvedUrl = sourceManager.getCipherManager()
         .resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), format);
 
-    if (client.getIdentifier().equals(Web.BASE_CONFIG.getName()) && Web.poToken != null) {
-      log.debug("Format origin is {}, setting 'pot' parameter.", client.getIdentifier());
-      URIBuilder builder = new URIBuilder(signedUrl);
-      builder.addParameter("pot", Web.poToken);
-      signedUrl = builder.build();
-    }
+    resolvedUrl = client.transformPlaybackUri(format.getUrl(), resolvedUrl);
 
-    return new FormatWithUrl(format, signedUrl);
+    return new FormatWithUrl(format, resolvedUrl);
   }
 
   @Override

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -15,9 +15,11 @@ import dev.lavalink.youtube.CannotBeLoaded;
 import dev.lavalink.youtube.UrlTools;
 import dev.lavalink.youtube.UrlTools.UrlInfo;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.clients.Web;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import dev.lavalink.youtube.track.format.StreamFormat;
 import dev.lavalink.youtube.track.format.TrackFormats;
+import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -190,6 +192,13 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     URI signedUrl = sourceManager.getCipherManager()
         .resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), format);
+
+    if (client.getIdentifier().equals(Web.BASE_CONFIG.getName()) && Web.poToken != null) {
+      log.debug("Format origin is {}, setting 'pot' parameter.", client.getIdentifier());
+      URIBuilder builder = new URIBuilder(signedUrl);
+      builder.addParameter("pot", Web.poToken);
+      signedUrl = builder.build();
+    }
 
     return new FormatWithUrl(format, signedUrl);
   }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/Pot.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/Pot.java
@@ -1,0 +1,22 @@
+package dev.lavalink.youtube.plugin;
+
+public class Pot {
+    private String token;
+    private String visitorData;
+
+    public String getToken() {
+        return token != null && !token.isEmpty() ? token : null;
+    }
+
+    public String getVisitorData() {
+        return visitorData != null && !visitorData.isEmpty() ? visitorData : null;
+    }
+
+    public void setPoToken(String token) {
+        this.token = token;
+    }
+
+    public void setVisitorData(String visitorData) {
+        this.visitorData = visitorData;
+    }
+}

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/Pot.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/Pot.java
@@ -12,7 +12,7 @@ public class Pot {
         return visitorData != null && !visitorData.isEmpty() ? visitorData : null;
     }
 
-    public void setPoToken(String token) {
+    public void setToken(String token) {
         this.token = token;
     }
 

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
@@ -14,7 +14,7 @@ public class YoutubeConfig {
     private boolean allowSearch = true;
     private boolean allowDirectVideoIds = true;
     private boolean allowDirectPlaylistIds = true;
-    private String poToken;
+    private Pot pot = null;
     private String[] clients;
     private Map<String, ClientOptions> clientOptions = new HashMap<>();
 
@@ -34,8 +34,8 @@ public class YoutubeConfig {
         return allowDirectPlaylistIds;
     }
 
-    public String getPoToken() {
-        return poToken;
+    public Pot getPot() {
+        return pot;
     }
 
     public String[] getClients() {
@@ -62,8 +62,8 @@ public class YoutubeConfig {
         this.allowDirectPlaylistIds = allowDirectPlaylistIds;
     }
 
-    public void setPoToken(String poToken) {
-        this.poToken = poToken;
+    public void setPot(Pot pot) {
+        this.pot = pot;
     }
 
     public void setClients(String[] clients) {

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeConfig.java
@@ -14,31 +14,36 @@ public class YoutubeConfig {
     private boolean allowSearch = true;
     private boolean allowDirectVideoIds = true;
     private boolean allowDirectPlaylistIds = true;
+    private String poToken;
     private String[] clients;
     private Map<String, ClientOptions> clientOptions = new HashMap<>();
 
     public boolean getEnabled() {
-        return this.enabled;
+        return enabled;
     }
 
     public boolean getAllowSearch() {
-        return this.allowSearch;
+        return allowSearch;
     }
 
     public boolean getAllowDirectVideoIds() {
-        return this.allowDirectVideoIds;
+        return allowDirectVideoIds;
     }
 
     public boolean getAllowDirectPlaylistIds() {
-        return this.allowDirectPlaylistIds;
+        return allowDirectPlaylistIds;
+    }
+
+    public String getPoToken() {
+        return poToken;
     }
 
     public String[] getClients() {
-        return this.clients;
+        return clients;
     }
 
     public Map<String, ClientOptions> getClientOptions() {
-        return this.clientOptions;
+        return clientOptions;
     }
 
     public void setEnabled(boolean enabled) {
@@ -55,6 +60,10 @@ public class YoutubeConfig {
 
     public void setAllowDirectPlaylistIds(boolean allowDirectPlaylistIds) {
         this.allowDirectPlaylistIds = allowDirectPlaylistIds;
+    }
+
+    public void setPoToken(String poToken) {
+        this.poToken = poToken;
     }
 
     public void setClients(String[] clients) {

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -8,7 +8,6 @@ import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
 import dev.arbjerg.lavalink.api.AudioPlayerManagerConfiguration;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
-import dev.lavalink.youtube.clients.ClientConfig;
 import dev.lavalink.youtube.clients.ClientOptions;
 import dev.lavalink.youtube.clients.Web;
 import dev.lavalink.youtube.clients.skeleton.Client;
@@ -163,11 +162,18 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
                 clients = clientProvider.getDefaultClients();
             } else {
                 clients = youtubeConfig.getClients();
-                String poToken = youtubeConfig.getPoToken();
+                Pot pot = youtubeConfig.getPot();
 
-                if (poToken != null && !poToken.isEmpty()) {
-                    log.debug("Setting poToken for WEB client to {}", poToken);
-                    Web.setPoToken(poToken);
+                if (pot != null) {
+                    String token = pot.getToken();
+                    String visitorData = pot.getVisitorData();
+
+                    if (token != null && visitorData != null) {
+                        log.debug("Applying poToken and visitorData to WEB client (token: {}, vd: {})", token, visitorData);
+                        Web.setPoTokenAndVisitorData(token, visitorData);
+                    } else if (token != null || visitorData != null) {
+                        log.warn("Both pot.token and pot.visitorData must be specified and valid for pot to apply.");
+                    }
                 }
             }
 

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubePluginLoader.java
@@ -8,7 +8,9 @@ import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
 import dev.arbjerg.lavalink.api.AudioPlayerManagerConfiguration;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.clients.ClientConfig;
 import dev.lavalink.youtube.clients.ClientOptions;
+import dev.lavalink.youtube.clients.Web;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import lavalink.server.config.RateLimitConfig;
 import lavalink.server.config.ServerConfig;
@@ -161,6 +163,12 @@ public class YoutubePluginLoader implements AudioPlayerManagerConfiguration {
                 clients = clientProvider.getDefaultClients();
             } else {
                 clients = youtubeConfig.getClients();
+                String poToken = youtubeConfig.getPoToken();
+
+                if (poToken != null && !poToken.isEmpty()) {
+                    log.debug("Setting poToken for WEB client to {}", poToken);
+                    Web.setPoToken(poToken);
+                }
             }
 
             source = new YoutubeAudioSourceManager(allowSearch, allowDirectVideoIds, allowDirectPlaylistIds, clientProvider.getClients(clients, this::getOptionsForClient));


### PR DESCRIPTION
This PR implements support for setting a `poToken` and accompanying `visitorData` values which currently apply to the `WEB` client. As of a recent change to YT's API, the WEB client may trigger 403 errors which can not be bypassed without specifying a `poToken`  (proof-of-origin token).

On a longer timeline, I would like to make this an automatic process that is handled automatically by the source manager however due to the complexity of that, and with current time constraints, this should suffice.

From what I gather, this has been successfully used in production environments by a handful of users.
Token lifetime is currently unknown but seems to be quite a while. With that, the only real drawback to this feature is potentially having to periodically update tokens manually.