### PR TITLE
Restore Android client playback ability and upgrade client version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Log file
 *.log
 
+
 # BlueJ files
 *.ctxt
 
@@ -28,6 +29,7 @@ replay_pid*
 .DS_Store
 */build/*
 build
+.vscode/*
 
 application.yml
 playerconfigs/*

--- a/README.md
+++ b/README.md
@@ -193,11 +193,12 @@ Currently, the following clients are available for use:
   - ❌ No mix/playlist/search support.
 - `ANDROID`
   - ❌ Heavily restricted, frequently dysfunctional.
+  - ✔ Opus formats.
 - `ANDROID_TESTSUITE`
   - ✔ Opus formats.
   - ❌ No mix/playlist/livestream support.
 - `ANDROID_MUSIC`
-  - ✔ Opus formats.
+  - ✔ No opus formats for livestreams (requires transcoding).
   - ❌ No playlist/livestream support.
 - `ANDROID_VR`
   - ✔ Opus formats.

--- a/common/src/main/java/dev/lavalink/youtube/clients/Android.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Android.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 public class Android extends StreamingNonMusicClient {
     private static final Logger log = LoggerFactory.getLogger(Android.class);
 
-    public static String CLIENT_VERSION = "19.07.39";
+    public static String CLIENT_VERSION = "19.32.24";
     public static AndroidVersion ANDROID_VERSION = AndroidVersion.ANDROID_11;
 
     public static ClientConfig BASE_CONFIG = new ClientConfig()
@@ -48,7 +48,7 @@ public class Android extends StreamingNonMusicClient {
     @Override
     @NotNull
     public String getPlayerParams() {
-        return MOBILE_PLAYER_PARAMS;
+        return null;
     }
 
     @Override

--- a/common/src/main/java/dev/lavalink/youtube/clients/AndroidLite.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/AndroidLite.java
@@ -36,6 +36,12 @@ public class AndroidLite extends Android {
     }
 
     @Override
+    @NotNull
+    public String getPlayerParams() {
+        return MOBILE_PLAYER_PARAMS;
+    }
+
+    @Override
     public boolean canHandleRequest(@NotNull String identifier) {
         // loose check to avoid loading mixes/playlists.
         return !identifier.contains("list=") && super.canHandleRequest(identifier);

--- a/common/src/main/java/dev/lavalink/youtube/clients/AndroidMusic.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/AndroidMusic.java
@@ -43,6 +43,12 @@ public class AndroidMusic extends Android {
 
     @Override
     @NotNull
+    public String getPlayerParams() {
+        return MOBILE_PLAYER_PARAMS;
+    }
+
+    @Override
+    @NotNull
     protected JsonBrowser extractMixPlaylistData(@NotNull JsonBrowser json) {
         return json.get("contents")
             .get("singleColumnMusicWatchNextResultsRenderer")

--- a/common/src/main/java/dev/lavalink/youtube/clients/AndroidTestsuite.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/AndroidTestsuite.java
@@ -39,6 +39,12 @@ public class AndroidTestsuite extends Android {
     }
 
     @Override
+    @NotNull
+    public String getPlayerParams() {
+        return MOBILE_PLAYER_PARAMS;
+    }
+
+    @Override
     public boolean canHandleRequest(@NotNull String identifier) {
         // loose check to avoid loading mixes/playlists.
         return !identifier.contains("list=") && super.canHandleRequest(identifier);

--- a/common/src/main/java/dev/lavalink/youtube/clients/AndroidVr.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/AndroidVr.java
@@ -33,6 +33,12 @@ public class AndroidVr extends Android {
 
     @Override
     @NotNull
+    public String getPlayerParams() {
+        return MOBILE_PLAYER_PARAMS;
+    }
+
+    @Override
+    @NotNull
     public String getIdentifier() {
         return BASE_CONFIG.getName();
     }

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -93,11 +93,15 @@ public abstract class NonMusicClient implements Client {
                 .withThirdPartyEmbedUrl("https://google.com");
         }
 
-        String payload = config.withRootField("videoId", videoId)
+        config.withRootField("videoId", videoId)
             .withRootField("racyCheckOk", true)
-            .withRootField("contentCheckOk", true)
-            .withRootField("params", getPlayerParams())
-            .withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)
+            .withRootField("contentCheckOk", true);
+
+        if (getPlayerParams() != null) {
+            config.withRootField("params" , getPlayerParams());
+        }
+
+        String payload = config.withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)
             .setAttributes(httpInterface)
             .toJsonString();
 


### PR DESCRIPTION
* I removed the `%` symbols from `MOBILE_PLAYER_PARAMS`, and it is now working fine. Although stream URLs return a `403: Not Success Status Code`, they work fine with OAuth.
* I noticed that `ANDROID_MUSIC` always throws a `NullPointerException` when used for search: https://mystb.in/8e32eef8d377e2282f.
* I verified that this PR does not break any other clients using `MOBILE_PLAYER_PARAMS`. The `ANDROID_MUSIC` client can't perform searches due to missing keys in the API response, but playback works fine. It can still be used for playback by disabling search and video loading.
* The `WEB` client playback is broken, as stream URLs return a `403: Not Success Status Code`, even with OAuth.