### PR TITLE
Implement ANDROID_VR and de-prioritise TVHTML5EMBEDDED

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ plugins:
     # Clients are queried in the order they are given (so the first client is queried first and so on...)
     clients:
       - MUSIC
-      - ANDROID_TESTSUITE
+      - ANDROID_VR
       - WEB
-      - TVHTML5EMBEDDED
+      - WEBEMBEDDED 
 ```
 
 ### Advanced Options
@@ -173,7 +173,7 @@ plugins:
         # Example: Disabling a client's playback capabilities.
         playback: false
         videoLoading: false # Disables loading of videos for this client. A client may still be used for playback even if this is set to 'false'.
-      TVHTML5EMBEDDED:
+      WEBEMBEDDED:
         # Example: Configuring a client to exclusively be used for video loading and playback.
         playlistLoading: false # Disables loading of playlists and mixes.
         searching: false # Disables the ability to search for videos.
@@ -199,6 +199,9 @@ Currently, the following clients are available for use:
 - `ANDROID_MUSIC`
   - ✔ Opus formats.
   - ❌ No playlist/livestream support.
+- `ANDROID_VR`
+  - ✔ Opus formats.
+  - ❌ No 'YouTube Kids' video support.
 - `MEDIA_CONNECT`
   - ❌ No Opus formats (requires transcoding).
   - ❌ No mix/playlist/search support.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ Currently, the following clients are available for use:
   - ❌ No playlist/livestream support.
 - `ANDROID_VR`
   - ✔ Opus formats.
-  - ❌ No 'YouTube Kids' video support.
 - `MEDIA_CONNECT`
   - ❌ No Opus formats (requires transcoding).
   - ❌ No mix/playlist/search support.
@@ -210,7 +209,7 @@ Currently, the following clients are available for use:
 - `TVHTML5EMBEDDED`
   - ✔ Opus formats.
   - ❌ No playlist support.
-  - ❌ Cannot be used for playback when logged out.
+  - ❌ Playback requires sign-in.
 
 ## Using OAuth Tokens
 You may notice that some requests are flagged by YouTube, causing an error message asking you to sign in to confirm you're not a bot.
@@ -390,11 +389,6 @@ In addition, there are a few significant changes to note:
 - This source's class structure differs so if you had custom classes that you were initialising
   the source manager with (e.g. an overridden `YoutubeTrackDetailsLoader`), this **is not** compatible
   with this source manager.
-
-- Support for logging into accounts as a means of playing age-restricted tracks has been removed.
-  There were a large number of reasons for this change, but not least the fact that logging in was slowly becoming 
-  problematic and deprecated on the YouTube backend. The amount of code to support this feature meant that it has been
-  axed. The `WEBEMBEDDED` client allows you to play some age-restricted videos, but not all.
 
 ## Additional Support
 If you need additional help with using this source, that's not covered here or in any of the issues, 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Currently, the following clients are available for use:
   - ✔ Opus formats.
 - `WEBEMBEDDED`
   - ✔ Opus formats.
+  - ✔ Limited age-restricted video playback.
   - ❌ No mix/playlist/search support.
 - `ANDROID`
   - ❌ Heavily restricted, frequently dysfunctional.
@@ -205,8 +206,8 @@ Currently, the following clients are available for use:
   - ❌ No Opus formats (requires transcoding).
 - `TVHTML5EMBEDDED`
   - ✔ Opus formats.
-  - ✔ Age-restricted video playback.
   - ❌ No playlist support.
+  - ❌ Cannot be used for playback when logged out.
 
 ## Using OAuth Tokens
 You may notice that some requests are flagged by YouTube, causing an error message asking you to sign in to confirm you're not a bot.
@@ -387,10 +388,10 @@ In addition, there are a few significant changes to note:
   the source manager with (e.g. an overridden `YoutubeTrackDetailsLoader`), this **is not** compatible
   with this source manager.
 
-- Support for logging into accounts as a means of playing age-restricted tracks has been removed, with the
-  `TVHTML5EMBEDDED` client instead being the preferred workaround. There were a large number of
-  reasons for this change, but not least the fact that logging in was slowly becoming problematic and deprecated
-  on the YouTube backend. The amount of code to support this feature meant that it has been axed.
+- Support for logging into accounts as a means of playing age-restricted tracks has been removed.
+  There were a large number of reasons for this change, but not least the fact that logging in was slowly becoming 
+  problematic and deprecated on the YouTube backend. The amount of code to support this feature meant that it has been
+  axed. The `WEBEMBEDDED` client allows you to play some age-restricted videos, but not all.
 
 ## Additional Support
 If you need additional help with using this source, that's not covered here or in any of the issues, 

--- a/common/src/main/java/dev/lavalink/youtube/clients/AndroidVr.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/AndroidVr.java
@@ -1,0 +1,39 @@
+package dev.lavalink.youtube.clients;
+
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import dev.lavalink.youtube.clients.ClientConfig.AndroidVersion;
+import org.jetbrains.annotations.NotNull;
+
+public class AndroidVr extends Android {
+    public static String CLIENT_VERSION = "1.60.18";
+    public static AndroidVersion ANDROID_VERSION = AndroidVersion.ANDROID_12L;
+
+    public static ClientConfig BASE_CONFIG = new ClientConfig()
+        .withApiKey(Android.BASE_CONFIG.getApiKey())
+        .withUserAgent(String.format("com.google.android.apps.youtube.vr.oculus/%s (Linux; U; Android %s; eureka-user Build/SQ3A.220605.009.A1) gzip", CLIENT_VERSION, ANDROID_VERSION.getOsVersion()))
+        .withClientName("ANDROID_VR")
+        .withClientField("clientVersion", CLIENT_VERSION)
+        .withClientField("androidSdkVersion", ANDROID_VERSION.getSdkVersion());
+
+    protected ClientOptions options;
+
+    public AndroidVr() {
+        this(ClientOptions.DEFAULT);
+    }
+
+    public AndroidVr(@NotNull ClientOptions options) {
+        super(options, false);
+    }
+
+    @Override
+    @NotNull
+    protected ClientConfig getBaseClientConfig(@NotNull HttpInterface httpInterface) {
+        return BASE_CONFIG.copy();
+    }
+
+    @Override
+    @NotNull
+    public String getIdentifier() {
+        return BASE_CONFIG.getName();
+    }
+}

--- a/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
@@ -173,8 +173,8 @@ public class ClientConfig {
     public enum AndroidVersion {
         // https://apilevels.com/
         ANDROID_13("13", 33),
-        ANDROID_12("12", 31),
         ANDROID_12L("12L", 32),
+        ANDROID_12("12", 31),
         ANDROID_11("11", 30);
 
         private final String osVersion;

--- a/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
@@ -173,7 +173,8 @@ public class ClientConfig {
     public enum AndroidVersion {
         // https://apilevels.com/
         ANDROID_13("13", 33),
-        ANDROID_12("12", 31), // 12L => 32
+        ANDROID_12("12", 31),
+        ANDROID_12L("12L", 32),
         ANDROID_11("11", 30);
 
         private final String osVersion;

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -87,8 +87,8 @@ public abstract class NonMusicClient implements Client {
 
         ClientConfig config = getBaseClientConfig(httpInterface);
 
-        if (status == null || isEmbedded()) {
-            // Only add embed info if the status and client are embeddable..
+        if (status == null) {
+            // Only add embed info if the status is not NON_EMBEDDABLE.
             config.withClientField("clientScreen", "EMBED")
                 .withThirdPartyEmbedUrl("https://google.com");
         }

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -87,8 +87,8 @@ public abstract class NonMusicClient implements Client {
 
         ClientConfig config = getBaseClientConfig(httpInterface);
 
-        if (status == null) {
-            // Only add embed info if the status is not NON_EMBEDDABLE.
+        if (status == null || isEmbedded()) {
+            // Only add embed info if the status and client are embeddable..
             config.withClientField("clientScreen", "EMBED")
                 .withThirdPartyEmbedUrl("https://google.com");
         }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/ClientProviderV3.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/ClientProviderV3.java
@@ -14,6 +14,7 @@ public class ClientProviderV3 implements ClientProvider {
         ANDROID_TESTSUITE(AndroidTestsuite::new),
         ANDROID_LITE(AndroidLite::new),
         ANDROID_MUSIC(AndroidMusic::new),
+        ANDROID_VR(AndroidVr::new),
         IOS(Ios::new),
         MUSIC(Music::new),
         TVHTML5EMBEDDED(TvHtml5Embedded::new),

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/ClientProviderV4.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/ClientProviderV4.java
@@ -15,6 +15,7 @@ public class ClientProviderV4 implements ClientProvider {
         ANDROID_TESTSUITE(AndroidTestsuiteWithThumbnail::new),
         ANDROID_LITE(AndroidLiteWithThumbnail::new),
         ANDROID_MUSIC(AndroidMusicWithThumbnail::new),
+        ANDROID_VR(AndroidVrWithThumbnail::new),
         IOS(IosWithThumbnail::new),
         MUSIC(MusicWithThumbnail::new),
         TVHTML5EMBEDDED(TvHtml5EmbeddedWithThumbnail::new),

--- a/v2/src/main/java/dev/lavalink/youtube/clients/AndroidVrWithThumbnail.java
+++ b/v2/src/main/java/dev/lavalink/youtube/clients/AndroidVrWithThumbnail.java
@@ -4,7 +4,9 @@ import dev.lavalink.youtube.clients.skeleton.NonMusicClientWithThumbnail;
 import org.jetbrains.annotations.NotNull;
 
 public class AndroidVrWithThumbnail extends AndroidVr implements NonMusicClientWithThumbnail {
-    public AndroidVrWithThumbnail() { super(); }
+    public AndroidVrWithThumbnail() {
+        super();
+    }
 
     public AndroidVrWithThumbnail(@NotNull ClientOptions options) {
         super(options);

--- a/v2/src/main/java/dev/lavalink/youtube/clients/AndroidVrWithThumbnail.java
+++ b/v2/src/main/java/dev/lavalink/youtube/clients/AndroidVrWithThumbnail.java
@@ -1,0 +1,12 @@
+package dev.lavalink.youtube.clients;
+
+import dev.lavalink.youtube.clients.skeleton.NonMusicClientWithThumbnail;
+import org.jetbrains.annotations.NotNull;
+
+public class AndroidVrWithThumbnail extends AndroidVr implements NonMusicClientWithThumbnail {
+    public AndroidVrWithThumbnail() { super(); }
+
+    public AndroidVrWithThumbnail(@NotNull ClientOptions options) {
+        super(options);
+    }
+}


### PR DESCRIPTION
This PR sdds the `ANDROID_VR` client which I expect to be less volatile than `ANDROID`.

`TVHTML5_SIMPLY_EMBEDDED_PLAYER` is no longer properly functional as it asks to sign in for every video regardless of if the IP is flagged or not.

`WEB_EMBEDDED_PLAYER` allows **some** age-restricted videos to be played, for example https://youtube.com/watch?v=HtVdAasjOgU.