### PR TITLE
Refine error message by removing duplicate word

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -113,7 +113,7 @@ public abstract class NonMusicClient implements Client {
         // An exception will be thrown if we can't handle it.
         if (playabilityStatus == PlayabilityStatus.NON_EMBEDDABLE) {
             if (isEmbedded()) {
-                throw new FriendlyException("Loading information for for video failed", Severity.COMMON,
+                throw new FriendlyException("Loading information for video failed", Severity.COMMON,
                     new RuntimeException("Non-embeddable video cannot be loaded by embedded client"));
             }
 
@@ -124,7 +124,7 @@ public abstract class NonMusicClient implements Client {
         JsonBrowser videoDetails = json.get("videoDetails");
 
         if (videoDetails.isNull()) {
-            throw new FriendlyException("Loading information for for video failed", Severity.SUSPICIOUS,
+            throw new FriendlyException("Loading information for video failed", Severity.SUSPICIOUS,
                 new RuntimeException("Missing videoDetails block, JSON: " + json.format()));
         }
 


### PR DESCRIPTION
This pull request refines an error message by removing the duplicated word "for" in the string "Loading information for for video failed." This change improves the readability and accuracy of the error message displayed to users.