### PR TITLE
Apply Access Token Only to PLAYER_URL to Resolve OAuth Error

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -9,6 +9,7 @@ import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
+import dev.lavalink.youtube.clients.skeleton.Client;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -255,6 +256,10 @@ public class YoutubeOauth2Handler {
 
     public void applyToken(HttpUriRequest request) {
         if (!enabled || DataFormatTools.isNullOrEmpty(refreshToken)) {
+            return;
+        }
+
+        if (!Client.PLAYER_URL.equals(request.getURI().toString())) {
             return;
         }
 


### PR DESCRIPTION
This pull request adjusts the application of the access token so that it is only applied to the `PLAYER_URL`. Through testing, I confirmed that searching for music does not require the access token, and applying it in that context resulted in the following error:

```
Invalid status code for search music response: 400
```

By ensuring the access token is only applied where necessary (`PLAYER_URL`), this fix restores proper OAuth functionality. The changes have been thoroughly tested with 200 players to verify that they work as expected.