### PR TITLE
Support attaching oauth token in userdata on track

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ plugins:
       # skipInitialization: true
 ```
 
+### Passing an oauth token from your client
+Another option to use oauth is by using oauth access tokens that are managed from your client. In this case your 
+bot/client provides LavaLink with the token to use when playing a track. To do this simply add the oauth access token 
+to a track's [userData](https://lavalink.dev/api/rest#track) field in a json format when updating the player to 
+play a track like:
+```json
+{
+  "oauth-token": "access token to use"
+}
+```
+
 ## Using a `poToken`
 A `poToken`, also known as a "Proof of Origin Token" is a way to identify what requests originate from.
 In YouTube's case, this is sent as a JavaScript challenge that browsers must evaluate, and send back the resolved

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
@@ -81,12 +81,11 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
         context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
       }
 
-      // Look at the userdata for any provided oauth-token
-      String oauthToken = context.getAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, String.class);
-
       boolean isRequestFromOauthedClient = context.getAttribute(Client.OAUTH_CLIENT_ATTRIBUTE) == Boolean.TRUE;
 
       if (isRequestFromOauthedClient && Client.PLAYER_URL.equals(request.getURI().toString())) {
+        // Look at the userdata for any provided oauth-token
+        String oauthToken = context.getAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, String.class);
         // only apply the token to /player requests.
         if (oauthToken != null) {
           oauth2Handler.applyToken(request, oauthToken);

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.COMMON;
+import static dev.lavalink.youtube.http.YoutubeOauth2Handler.OAUTH_INJECT_CONTEXT_ATTRIBUTE;
 
 public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
   private static final Logger log = LoggerFactory.getLogger(YoutubeHttpContextFilter.class);
@@ -80,11 +81,18 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
         context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
       }
 
+      // Look at the userdata for any provided oauth-token
+      String oauthToken = context.getAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, String.class);
+
       boolean isRequestFromOauthedClient = context.getAttribute(Client.OAUTH_CLIENT_ATTRIBUTE) == Boolean.TRUE;
 
       if (isRequestFromOauthedClient && Client.PLAYER_URL.equals(request.getURI().toString())) {
         // only apply the token to /player requests.
-        oauth2Handler.applyToken(request);
+        if (oauthToken != null) {
+          oauth2Handler.applyToken(request, oauthToken);
+        } else {
+          oauth2Handler.applyToken(request);
+        }
       }
     }
 

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeHttpContextFilter.java
@@ -87,7 +87,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
         // Look at the userdata for any provided oauth-token
         String oauthToken = context.getAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, String.class);
         // only apply the token to /player requests.
-        if (oauthToken != null) {
+        if (oauthToken != null && !oauthToken.isEmpty()) {
           oauth2Handler.applyToken(request, oauthToken);
         } else {
           oauth2Handler.applyToken(request);

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -291,7 +291,7 @@ public class YoutubeOauth2Handler {
     }
 
     public void applyToken(HttpUriRequest request, String token) {
-            request.setHeader("Authorization", String.format("%s %s", "Bearer", token));
+        request.setHeader("Authorization", String.format("%s %s", "Bearer", token));
     }
 
     private HttpInterface getHttpInterface() {

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -35,7 +35,7 @@ public class YoutubeOauth2Handler {
     private static final String CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT";
     private static final String SCOPES = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube";
     private static final String OAUTH_FETCH_CONTEXT_ATTRIBUTE = "yt-oauth";
-    public static final String OAUTH_INJECT_CONTEXT_ATTRIBUTE = "yt-oauth-injection";
+    public static final String OAUTH_INJECT_CONTEXT_ATTRIBUTE = "yt-oauth-token";
 
     private final HttpInterfaceManager httpInterfaceManager;
 
@@ -291,10 +291,6 @@ public class YoutubeOauth2Handler {
     }
 
     public void applyToken(HttpUriRequest request, String token) {
-        if (!Client.PLAYER_URL.equals(request.getURI().toString())) {
-            return;
-        }
-
         if (token != null && !token.isEmpty()) {
             request.setHeader("Authorization", String.format("%s %s", "Bearer", token));
         }

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +36,7 @@ public class YoutubeOauth2Handler {
     private static final String CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT";
     private static final String SCOPES = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube";
     private static final String OAUTH_FETCH_CONTEXT_ATTRIBUTE = "yt-oauth";
+    public static final String OAUTH_INJECT_CONTEXT_ATTRIBUTE = "yt-oauth-injection";
 
     private final HttpInterfaceManager httpInterfaceManager;
 
@@ -286,6 +288,16 @@ public class YoutubeOauth2Handler {
         if (accessToken != null && tokenType != null && System.currentTimeMillis() < tokenExpires) {
             log.debug("Using oauth authorization header with value \"{} {}\"", tokenType, accessToken);
             request.setHeader("Authorization", String.format("%s %s", tokenType, accessToken));
+        }
+    }
+
+    public void applyToken(HttpUriRequest request, String token) {
+        if (!Client.PLAYER_URL.equals(request.getURI().toString())) {
+            return;
+        }
+
+        if (token != null && !token.isEmpty()) {
+            request.setHeader("Authorization", String.format("%s %s", "Bearer", token));
         }
     }
 

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -291,9 +291,7 @@ public class YoutubeOauth2Handler {
     }
 
     public void applyToken(HttpUriRequest request, String token) {
-        if (token != null && !token.isEmpty()) {
             request.setHeader("Authorization", String.format("%s %s", "Bearer", token));
-        }
     }
 
     private HttpInterface getHttpInterface() {

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -2,6 +2,7 @@ package dev.lavalink.youtube.track;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
 import com.sedmelluq.discord.lavaplayer.container.matroska.MatroskaAudioTrack;
 import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
@@ -69,9 +70,13 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     }
 
     try (HttpInterface httpInterface = sourceManager.getInterface()) {
-      JsonObject userData = JsonParser.object().from(getUserData().toString());
-      if (userData.has("oauth-token")) {
-        httpInterface.getContext().setAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, userData.getString("oauth-token"));
+      try {
+        JsonObject userData = JsonParser.object().from(getUserData().toString());
+        if (userData.has("oauth-token")) {
+          httpInterface.getContext().setAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, userData.getString("oauth-token"));
+        }
+      } catch (JsonParserException e) {
+        log.debug("Failed to parse token from userData", e);
       }
       Exception lastException = null;
 

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -1,5 +1,7 @@
 package dev.lavalink.youtube.track;
 
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
 import com.sedmelluq.discord.lavaplayer.container.matroska.MatroskaAudioTrack;
 import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
@@ -32,6 +34,7 @@ import java.util.Map;
 import static com.sedmelluq.discord.lavaplayer.container.Formats.MIME_AUDIO_WEBM;
 import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.decodeUrlEncodedItems;
 import static com.sedmelluq.discord.lavaplayer.tools.Units.CONTENT_LENGTH_UNKNOWN;
+import static dev.lavalink.youtube.http.YoutubeOauth2Handler.OAUTH_INJECT_CONTEXT_ATTRIBUTE;
 
 /**
  * Audio track that handles processing Youtube videos as audio tracks.
@@ -66,6 +69,10 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     }
 
     try (HttpInterface httpInterface = sourceManager.getInterface()) {
+      JsonObject userData = JsonParser.object().from(getUserData().toString());
+      if (userData.has("oauth-token")) {
+        httpInterface.getContext().setAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, userData.getString("oauth-token"));
+      }
       Exception lastException = null;
 
       for (Client client : clients) {

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -1,14 +1,12 @@
 package dev.lavalink.youtube.track;
 
-import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 import com.sedmelluq.discord.lavaplayer.container.matroska.MatroskaAudioTrack;
 import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
+import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
@@ -27,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -71,11 +70,11 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     try (HttpInterface httpInterface = sourceManager.getInterface()) {
       try {
-        JsonObject userData = JsonParser.object().from(getUserData().toString());
-        if (userData.has("oauth-token")) {
-          httpInterface.getContext().setAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, userData.getString("oauth-token"));
+        JsonBrowser userData = JsonBrowser.parse(getUserData().toString());
+        if (userData.get("oauth-token") != null) {
+          httpInterface.getContext().setAttribute(OAUTH_INJECT_CONTEXT_ATTRIBUTE, userData.get("oauth-token").text());
         }
-      } catch (JsonParserException e) {
+      } catch (IOException e) {
         log.debug("Failed to parse token from userData", e);
       }
       Exception lastException = null;


### PR DESCRIPTION
This PR adds the ability to include oauth credentials on the userData of a track that are picked up and used when loading the track. 

### How to use
If you don't want to build it yourself, you can pull it built from here: 
https://maven.kikkia.dev/#/snapshots/dev/lavalink/youtube/youtube-plugin/0d161676dc220dfeb8719925b2afd0555eb56dcc
(Diff commit hash because its on a [branch](https://github.com/kikkia/youtube-source/tree/userdata-oauth-my-maven) that has the build file changed to my repo)

Add an "oauth-token" field to a tracks userData with a value of the accesstoken.

One question I had for people who know more than me, Will this cause an issue with the way the player script is cached at:
  https://github.com/kikkia/youtube-source/blob/ffc3fbae86efbd2664c1b884765abd57155b5c96/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipherManager.java#L191C3-L198C6?
  In my other oauth injection implementation I had this removed with a comment about some potential issues when using many different oauth accounts with the same cached player script. I don't have the ability to test with more than 1 concurrent stream tonight though. That was also a while ago so I forget if that was truly causing issues or more precautionary. 