### PR TITLE
Add manually runnable tests for user wanting to mess with cipher regexes

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     testImplementation(libs.lavaplayer.v1)
     testImplementation("org.apache.logging.log4j:log4j-core:2.19.0")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0-M1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.0-M1")
 }
 
 mavenPublishing {
@@ -35,5 +38,8 @@ tasks {
                 "version" to project.version
             )
         )
+    }
+    test {
+        useJUnitPlatform() // Enable JUnit Platform for running JUnit 5 tests
     }
 }

--- a/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipherManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipherManager.java
@@ -90,7 +90,15 @@ public class SignatureCipherManager {
           "\\s*return\\s*(\\2\\.join\\(\"\"\\)|Array\\.prototype\\.join\\.call\\(\\2,.*?\\))};", Pattern.DOTALL);
 
   private static final Pattern tceGlobalVarsPattern = Pattern.compile(
-      "(?:^|[;,])\\s*(var\\s+([\\w$]+)\\s*=\\s*\"(?:[^\"\\\\]|\\\\.)+\"\\s*\\.\\s*split\\(\"([^\"\\\\]|\\\\.)\"\\))(?=\\s*[,;])"
+          "(?:^|[;,])\\s*(var\\s+([\\w$]+)\\s*=\\s*" +
+                  "(?:" +
+                  "([\"'])(?:\\\\.|[^\\\\])*?\\3" +  // Matches a quoted string safely
+                  "\\s*\\.\\s*split\\((" +
+                  "([\"'])(?:\\\\.|[^\\\\])*?\\5" +  // Ensures same quote type in split()
+                  "\\))" +
+                  "|" +  // OR condition to handle array notation
+                  "\\[\\s*(?:([\"'])(?:\\\\.|[^\\\\])*?\\6\\s*,?\\s*)+\\]" +
+                  "))(?=\\s*[,;])"
   );
 
   private static final Pattern functionTcePattern = Pattern.compile(

--- a/common/src/test/java/SignatureCipherManagerTest.java
+++ b/common/src/test/java/SignatureCipherManagerTest.java
@@ -1,6 +1,5 @@
 import com.sedmelluq.discord.lavaplayer.tools.http.HttpContextFilter;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
-import dev.lavalink.youtube.cipher.SignatureCipher;
 import dev.lavalink.youtube.cipher.SignatureCipherManager;
 import dev.lavalink.youtube.track.format.StreamFormat;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -8,7 +7,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,43 +14,28 @@ import java.net.URI;
 
 @Disabled("Disabled since it's intended for manual use. Comment out to enable test")
 public class SignatureCipherManagerTest {
-    private String SCRIPT_URL = "https://www.youtube.com/s/player/4fcd6e4a/player_ias.vflset/en_US/base.js";
-
-    @Test
-    public void testGetCypherScript() throws IOException {
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            HttpInterface httpInterface = new HttpInterface(httpClient, new HttpClientContext(), true, noOpFilter);
-            SignatureCipherManager cipherManager = new SignatureCipherManager();
-
-            try {
-                SignatureCipher cipher = cipherManager.getCipherScript(httpInterface, SCRIPT_URL);
-
-                Assertions.assertNotNull(cipher);
-
-                Assertions.assertNotNull(cipher.nFunction);
-                Assertions.assertFalse(cipher.nFunction.isEmpty());
-                Assertions.assertTrue(cipher.nFunction.contains("function("));
-
-            } catch (IOException | IllegalStateException e) {
-                Assertions.fail("Failed to get or parse the cipher script: " + e.getMessage());
-            }
-        }
-    }
+    private TestCase[] scripts = new TestCase[]{
+            new TestCase("https://www.youtube.com/s/player/4fcd6e4a/player_ias.vflset/en_US/base.js", "o_L251jm8yhZkWtBW", "lXoxI3XvToqn6A", "2aq0aqSyOoJXtK73m-uME_jv7-pT15gOFC02RFkGMqWpzEICs69VdbwQ0LDp1v7j8xx92efCJlYFYb1sUkkBSPOlPmXgIARw8JQ0qOAOAA", "wAOAOq0QJ8ARAIgXmPlOPSBkkUs1bYFYlJCfe29xx8q7v1pDL0QwbdV96sCIEzpWqMGkFR20CFOg51Tp-7vj_EMu-m37KtXJoOySqa0"),
+            new TestCase("https://www.youtube.com/s/player/363db69b/player_ias.vflset/en_US/base.js", "eWYu5d5YeY_4LyEDc", "XJQqf-N7Xra3gg", "2aq0aqSyOoJXtK73m-uME_jv7-pT15gOFC02RFkGMqWpzEICs69VdbwQ0LDp1v7j8xx92efCJlYFYb1sUkkBSPOlPmXgIARw8JQ0qOAOAA", "0aqSyOoJXtK73m-uME_jv7-pT15gOFC02RFkGMqWpz2ICs6EVdbwQ0LDp1v7j8xx92efCJlYFYb1sUkkBSPOlPmXgIARw8JQ0qOAOAA")
+    };
 
     @Test
     public void testResolveFormatUrl() throws IOException {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpInterface httpInterface = new HttpInterface(httpClient, new HttpClientContext(), true, noOpFilter);
-            SignatureCipherManager cipherManager = new SignatureCipherManager();
+            for (TestCase test: scripts) {
+                SignatureCipherManager cipherManager = new SignatureCipherManager();
 
-            try {
-                URI uri = cipherManager.resolveFormatUrl(httpInterface, SCRIPT_URL, exampleStream);
+                try {
+                    URI uri = cipherManager.resolveFormatUrl(httpInterface, test.uri, getTestStream(test));
 
-                Assertions.assertNotNull(uri);
-                // Assert that our N param is set
-                Assertions.assertTrue(uri.toString().contains("&n="));
-            } catch (IOException | IllegalStateException e) {
-                Assertions.fail("Failed to get or parse the cipher script: " + e.getMessage());
+                    Assertions.assertNotNull(uri);
+                    // Assert that our N param is set
+                    Assertions.assertTrue(uri.toString().contains("n=" + test.expectedN));
+                    Assertions.assertTrue(uri.toString().contains("sig=" + test.expectedSig));
+                } catch (IOException | IllegalStateException e) {
+                    Assertions.fail("Failed to get or parse the cipher script: " + e.getMessage());
+                }
             }
         }
     }
@@ -84,16 +67,34 @@ public class SignatureCipherManagerTest {
         }
     };
 
-    private StreamFormat exampleStream = new StreamFormat(
-            ContentType.APPLICATION_OCTET_STREAM,
-            18,
-            128000,
-            1000000,
-            2,
-            "",
-            "u9L2ScigFKrnmOCJO",
-            "testSignature",
-            "sig",
-            true,
-            false);
+    private StreamFormat getTestStream(TestCase testCase) {
+        return new StreamFormat(
+                ContentType.APPLICATION_OCTET_STREAM,
+                18,
+                128000,
+                1000000,
+                2,
+                "",
+                testCase.nParam,
+                testCase.signature,
+                "sig",
+                true,
+                false);
+    }
+
+    private class TestCase {
+        String uri;
+        String nParam;
+        String expectedN;
+        String signature;
+        String expectedSig;
+
+        public TestCase(String uri, String nParam, String expectedN, String signature, String expectedSig) {
+            this.uri = uri;
+            this.nParam = nParam;
+            this.expectedN = expectedN;
+            this.signature = signature;
+            this.expectedSig = expectedSig;
+        }
+    }
 }

--- a/common/src/test/java/SignatureCipherManagerTest.java
+++ b/common/src/test/java/SignatureCipherManagerTest.java
@@ -7,6 +7,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/common/src/test/java/SignatureCipherManagerTest.java
+++ b/common/src/test/java/SignatureCipherManagerTest.java
@@ -1,0 +1,99 @@
+import com.sedmelluq.discord.lavaplayer.tools.http.HttpContextFilter;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import dev.lavalink.youtube.cipher.SignatureCipher;
+import dev.lavalink.youtube.cipher.SignatureCipherManager;
+import dev.lavalink.youtube.track.format.StreamFormat;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+@Disabled("Disabled since it's intended for manual use. Comment out to enable test")
+public class SignatureCipherManagerTest {
+    private String SCRIPT_URL = "https://www.youtube.com/s/player/4fcd6e4a/player_ias.vflset/en_US/base.js";
+
+    @Test
+    public void testGetCypherScript() throws IOException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpInterface httpInterface = new HttpInterface(httpClient, new HttpClientContext(), true, noOpFilter);
+            SignatureCipherManager cipherManager = new SignatureCipherManager();
+
+            try {
+                SignatureCipher cipher = cipherManager.getCipherScript(httpInterface, SCRIPT_URL);
+
+                Assertions.assertNotNull(cipher);
+
+                Assertions.assertNotNull(cipher.nFunction);
+                Assertions.assertFalse(cipher.nFunction.isEmpty());
+                Assertions.assertTrue(cipher.nFunction.contains("function("));
+
+            } catch (IOException | IllegalStateException e) {
+                Assertions.fail("Failed to get or parse the cipher script: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testResolveFormatUrl() throws IOException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpInterface httpInterface = new HttpInterface(httpClient, new HttpClientContext(), true, noOpFilter);
+            SignatureCipherManager cipherManager = new SignatureCipherManager();
+
+            try {
+                URI uri = cipherManager.resolveFormatUrl(httpInterface, SCRIPT_URL, exampleStream);
+
+                Assertions.assertNotNull(uri);
+                // Assert that our N param is set
+                Assertions.assertTrue(uri.toString().contains("&n="));
+            } catch (IOException | IllegalStateException e) {
+                Assertions.fail("Failed to get or parse the cipher script: " + e.getMessage());
+            }
+        }
+    }
+
+    HttpContextFilter noOpFilter = new HttpContextFilter() {
+        @Override
+        public void onContextOpen(HttpClientContext context) {
+            // No operation
+        }
+
+        @Override
+        public void onRequest(HttpClientContext context, org.apache.http.client.methods.HttpUriRequest request, boolean isRepetition) {
+            // No operation
+        }
+
+        @Override
+        public boolean onRequestResponse(HttpClientContext context, org.apache.http.client.methods.HttpUriRequest request, org.apache.http.HttpResponse response) {
+            return false; // Do not retry by default
+        }
+
+        @Override
+        public boolean onRequestException(HttpClientContext context, org.apache.http.client.methods.HttpUriRequest request, Throwable exception) {
+            return false; // Do not retry by default
+        }
+
+        @Override
+        public void onContextClose(HttpClientContext context) {
+            // No operation
+        }
+    };
+
+    private StreamFormat exampleStream = new StreamFormat(
+            ContentType.APPLICATION_OCTET_STREAM,
+            18,
+            128000,
+            1000000,
+            2,
+            "",
+            "u9L2ScigFKrnmOCJO",
+            "testSignature",
+            "sig",
+            true,
+            false);
+}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -41,6 +41,10 @@ mavenPublishing {
     configure(JavaLibrary(JavadocJar.None(), sourcesJar = false))
 }
 
+tasks.jar {
+    dependsOn(":common:compileTestJava")
+}
+
 tasks {
     processResources {
         filter<ReplaceTokens>(


### PR DESCRIPTION
Added some test cases for testing out cipher regexes. 

They are disabled by default because they depend on pulling the script from the internet. This is more about manually testing than for blocking a build or something. 