### PR TITLE
Added a new endpoint, youtube/createaccesstoken/{refreshToken}

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,28 @@ If `videoId` could not be found or loaded, or the `itag` does not exist, or if n
 Otherwise:
 `200 - OK` accompanied by the selected format stream (audio or video). `Content-Type` header will be set appropriately.
 
+### `GET` `/youtube/oauth/{refreshToken}`
+
+Response:
+
+If the `refreshToken` is invalid, expired, or cannot be processed:
+`500 - Internal Server Error`
+
+If the refresh process succeeds and a new access token is generated:
+`200 - OK` accompanied by the new access token in JSON format.
+
+Example response:
+```json
+{
+  "access_token": "AccessToken",
+  "expires_in": 69420,
+  "scope": "used scope",
+  "token_type": "type"
+}
+```
+
+
+
 ## Migration from Lavaplayer's built-in YouTube source
 
 This client is intended as a direct replacement for Lavaplayer's built-in `YoutubeAudioSourceManager`,

--- a/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
+++ b/common/src/main/java/dev/lavalink/youtube/http/YoutubeOauth2Handler.java
@@ -219,7 +219,6 @@ public class YoutubeOauth2Handler {
                 log.info("YouTube access token refreshed successfully");
                 log.debug("YouTube access token is {} and refresh token is {}. Access token expires in {} seconds.", accessToken, refreshToken, json.getLong("expires_in"));
             } catch (Exception e) {
-                log.error("Failed to refresh access token", e);
                 throw e;
             }
         }
@@ -228,18 +227,22 @@ public class YoutubeOauth2Handler {
 
     /**
      * Executes the HTTP request to refresh the access token and returns the response.
+     *
      * @param refreshToken The refresh token to be included in the request.
      * @return The JSON response as a JsonObject.
      */
     public JsonObject createNewAccessToken(String refreshToken) {
+
+        // @formatter:off
         String requestJson = JsonWriter.string()
                 .object()
-                .value("client_id", CLIENT_ID)
-                .value("client_secret", CLIENT_SECRET)
-                .value("refresh_token", refreshToken)
-                .value("grant_type", "refresh_token")
+                    .value("client_id", CLIENT_ID)
+                    .value("client_secret", CLIENT_SECRET)
+                    .value("refresh_token", refreshToken)
+                    .value("grant_type", "refresh_token")
                 .end()
                 .done();
+        // @formatter:on
 
         HttpPost request = new HttpPost("https://www.youtube.com/o/oauth2/token");
         StringEntity entity = new StringEntity(requestJson, ContentType.APPLICATION_JSON);

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -176,7 +176,7 @@ public class YoutubeRestHandler {
         return MinimalConfigResponse.from(getYoutubeSource());
     }
 
-    @GetMapping("/youtube/createaccesstoken/{refreshToken}")
+    @GetMapping("/youtube/oauth/{refreshToken}")
     public JsonObject createNewAccessToken(@PathVariable("refreshToken") String refreshToken) {
         return getYoutubeSource().getOauth2Handler().createNewAccessToken(refreshToken);
     }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -1,5 +1,6 @@
 package dev.lavalink.youtube.plugin;
 
+import com.grack.nanojson.JsonObject;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import dev.lavalink.youtube.CannotBeLoaded;
@@ -173,6 +174,11 @@ public class YoutubeRestHandler {
     @GetMapping("/youtube")
     public MinimalConfigResponse getYoutubeConfig() {
         return MinimalConfigResponse.from(getYoutubeSource());
+    }
+
+    @GetMapping("/youtube/createaccesstoken/{refreshToken}")
+    public JsonObject createNewAccessToken(@PathVariable("refreshToken") String refreshToken) {
+        return getYoutubeSource().getOauth2Handler().createNewAccessToken(refreshToken);
     }
 
     @PostMapping("/youtube")


### PR DESCRIPTION
Added a new endpoint, `youtube/createaccesstoken`, to allow users to create access tokens.

Why this change? 
@kikkia added OAuth tokens in userdata:  https://github.com/lavalink-devs/youtube-source/commit/edd66468bccabd8efb20e09b291061a1c9d187af

It would be beneficial for users to create refresh tokens and use them on the client side.  
Why not implement it client-side? Because of IPv6 rotation