### PR TITLE
fixed regex for player ids 22f02d3d & 6450230e

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/cipher/TCEVariable.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/TCEVariable.java
@@ -1,0 +1,32 @@
+package dev.lavalink.youtube.cipher;
+
+import org.jetbrains.annotations.NotNull;
+
+public class TCEVariable {
+    private final String name;
+    private final String code;
+    private final String value;
+
+    public TCEVariable(@NotNull String name, @NotNull String code, @NotNull String value) {
+        this.name = name;
+        this.code = code;
+        this.value = value;
+    }
+
+    public String getEscapedName() {
+        return this.name.replace("$", "\\$");
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+}


### PR DESCRIPTION
This fix is temporary. I’ve only tested it with player IDs `22f02d3d` and `6450230e` (probably work for atleast one month), and it uses the Rhino engine to evaluate the `sig` parameter from `s` (which may execute malicious code if Google tries something sketchy). Improvements are most welcome. If I get the time, I’ll try to make the regex backward-compatible.