### PR TITLE
Skip Player Script for Mobile Clients

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/cipher/ScriptExtractionException.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/ScriptExtractionException.java
@@ -1,0 +1,26 @@
+package dev.lavalink.youtube.cipher;
+
+public class ScriptExtractionException extends RuntimeException {
+    private final ExtractionFailureType failureType;
+
+    public enum ExtractionFailureType {
+        TIMESTAMP_NOT_FOUND,
+        ACTION_FUNCTIONS_NOT_FOUND,
+        DECIPHER_FUNCTION_NOT_FOUND,
+        N_FUNCTION_NOT_FOUND
+    }
+
+    public ScriptExtractionException(String message, ExtractionFailureType failureType) {
+        super(message);
+        this.failureType = failureType;
+    }
+
+    public ScriptExtractionException(String message, ExtractionFailureType failureType, Throwable cause) {
+        super(message, cause);
+        this.failureType = failureType;
+    }
+
+    public ExtractionFailureType getFailureType() {
+        return failureType;
+    }
+}

--- a/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipherManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipherManager.java
@@ -301,7 +301,8 @@ public class SignatureCipherManager {
     Matcher scriptTimestamp = timestampPattern.matcher(script);
     if (!scriptTimestamp.find()) {
       dumpProblematicScript(script, sourceUrl, "no timestamp match");
-      throw new IllegalStateException("Must find timestamp from script: " + sourceUrl);
+      throw new ScriptExtractionException("Must find timestamp from script: " + sourceUrl,
+              ScriptExtractionException.ExtractionFailureType.TIMESTAMP_NOT_FOUND);
     }
     
     TCEVariable tce;
@@ -331,7 +332,8 @@ public class SignatureCipherManager {
         usingGlobalLookup = true;
       } else {
         dumpProblematicScript(script, sourceUrl, "no actions match");
-        throw new IllegalStateException("Must find action functions from script: " + sourceUrl);
+        throw new ScriptExtractionException("Must find action functions from script: " + sourceUrl,
+                ScriptExtractionException.ExtractionFailureType.ACTION_FUNCTIONS_NOT_FOUND);
       }
     }
 
@@ -366,7 +368,8 @@ public class SignatureCipherManager {
         functions = functionTcePattern.matcher(script);
         if (!functions.find()) {
           dumpProblematicScript(script, sourceUrl, "no decipher function match");
-          throw new IllegalStateException("Must find decipher function from script.");
+          throw new ScriptExtractionException("Must find decipher function from script.",
+                  ScriptExtractionException.ExtractionFailureType.DECIPHER_FUNCTION_NOT_FOUND);
         }
         matchedTce = true;
       }
@@ -391,7 +394,8 @@ public class SignatureCipherManager {
 
           if (!nFunctionMatcher.find()) {
             dumpProblematicScript(script, sourceUrl, "no n function match");
-            throw new IllegalStateException("Must find n function from script: " + sourceUrl);
+            throw new ScriptExtractionException("Must find n function from script: " + sourceUrl,
+                    ScriptExtractionException.ExtractionFailureType.N_FUNCTION_NOT_FOUND);
           }
         }
       } else {
@@ -400,7 +404,8 @@ public class SignatureCipherManager {
 
         if (!nFunctionMatcher.find()) {
           dumpProblematicScript(script, sourceUrl, "no n function match");
-          throw new IllegalStateException("Must find n function from script: " + sourceUrl);
+          throw new ScriptExtractionException("Must find n function from script: " + sourceUrl,
+                  ScriptExtractionException.ExtractionFailureType.N_FUNCTION_NOT_FOUND);
         }
 
         // unconditionally set this to true.

--- a/common/src/main/java/dev/lavalink/youtube/clients/Android.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Android.java
@@ -86,7 +86,7 @@ public class Android extends StreamingNonMusicClient {
     }
 
     @Override
-    public boolean requiresJSScript() {
+    public boolean requirePlayerScript() {
         return false;
     }
 }

--- a/common/src/main/java/dev/lavalink/youtube/clients/Android.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Android.java
@@ -84,4 +84,9 @@ public class Android extends StreamingNonMusicClient {
                 .get("content")
                 .text();
     }
+
+    @Override
+    public boolean requiresJSScript() {
+        return false;
+    }
 }

--- a/common/src/main/java/dev/lavalink/youtube/clients/Ios.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Ios.java
@@ -74,4 +74,9 @@ public class Ios extends StreamingNonMusicClient {
     public String getIdentifier() {
         return BASE_CONFIG.getName();
     }
+
+    @Override
+    public boolean requiresJSScript() {
+        return false;
+    }
 }

--- a/common/src/main/java/dev/lavalink/youtube/clients/Ios.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Ios.java
@@ -76,7 +76,7 @@ public class Ios extends StreamingNonMusicClient {
     }
 
     @Override
-    public boolean requiresJSScript() {
+    public boolean requirePlayerScript() {
         return false;
     }
 }

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
@@ -208,7 +208,6 @@ public interface Client {
     default boolean supportsFormatLoading() {
         return getOptions().getPlayback();
     }
-
     
     default boolean isEmbedded() {
         return false;
@@ -221,7 +220,7 @@ public interface Client {
         return false;
     }
 
-    default boolean requirsJSScript() {
+    default boolean requiresJSScript() {
         return true;
     }
 

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
@@ -220,7 +220,7 @@ public interface Client {
         return false;
     }
 
-    default boolean requiresJSScript() {
+    default boolean requirePlayerScript() {
         return true;
     }
 

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/Client.java
@@ -221,6 +221,10 @@ public interface Client {
         return false;
     }
 
+    default boolean requirsJSScript() {
+        return true;
+    }
+
     void setPlaylistPageCount(int count);
 
     /**

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -106,8 +106,6 @@ public abstract class NonMusicClient implements Client {
                                                      @Nullable PlayabilityStatus status,
                                                      boolean validatePlayabilityStatus) throws CannotBeLoaded, IOException {
         SignatureCipherManager cipherManager = source.getCipherManager();
-        CachedPlayerScript playerScript = cipherManager.getCachedPlayerScript(httpInterface);
-        SignatureCipher signatureCipher = cipherManager.getCipherScript(httpInterface, playerScript.url);
 
         ClientConfig config = getBaseClientConfig(httpInterface);
 
@@ -127,9 +125,14 @@ public abstract class NonMusicClient implements Client {
             config.withRootField("params", params);
         }
 
-        String payload = config.withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)
-            .setAttributes(httpInterface)
-            .toJsonString();
+        String payload = config.setAttributes(httpInterface).toJsonString();;
+        if (this.requiresJSScript()) {
+            CachedPlayerScript playerScript = cipherManager.getCachedPlayerScript(httpInterface);
+            SignatureCipher signatureCipher = cipherManager.getCipherScript(httpInterface, playerScript.url);
+            payload = config.withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)
+                    .setAttributes(httpInterface)
+                    .toJsonString();
+        }
 
         HttpPost request = new HttpPost(PLAYER_URL);
         request.setEntity(new StringEntity(payload, "UTF-8"));

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -126,7 +126,7 @@ public abstract class NonMusicClient implements Client {
         }
 
         String payload = config.setAttributes(httpInterface).toJsonString();
-        if (requiresJSScript()) {
+        if (requirePlayerScript()) {
             CachedPlayerScript playerScript = cipherManager.getCachedPlayerScript(httpInterface);
             SignatureCipher signatureCipher = cipherManager.getCipherScript(httpInterface, playerScript.url);
             payload = config.withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -125,8 +125,8 @@ public abstract class NonMusicClient implements Client {
             config.withRootField("params", params);
         }
 
-        String payload = config.setAttributes(httpInterface).toJsonString();;
-        if (this.requiresJSScript()) {
+        String payload = config.setAttributes(httpInterface).toJsonString();
+        if (requiresJSScript()) {
             CachedPlayerScript playerScript = cipherManager.getCachedPlayerScript(httpInterface);
             SignatureCipher signatureCipher = cipherManager.getCipherScript(httpInterface, playerScript.url);
             payload = config.withPlaybackSignatureTimestamp(signatureCipher.scriptTimestamp)

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -108,7 +108,12 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
           if ("Not success status code: 403".equals(message) ||
               "Invalid status code for player api response: 400".equals(message) ||
-                  (message != null && (message.contains("No supported audio streams available") || message.contains("Must find action functions from script")))) {
+                  (message != null && (message.contains("No supported audio streams available") ||
+                          message.contains("Must find action functions from script") ||
+                          message.contains("Must find timestamp from script") ||
+                          message.contains("Must find decipher function from script") ||
+                          message.contains("Must find n function from script")
+                  ))) {
             // As long as the executor position has not surpassed the threshold for which
             // a stream is considered unrecoverable, we can try to renew the playback URL with
             // another client.

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -108,7 +108,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
           if ("Not success status code: 403".equals(message) ||
               "Invalid status code for player api response: 400".equals(message) ||
-              (message != null && message.contains("No supported audio streams available"))) {
+                  (message != null && (message.contains("No supported audio streams available") || message.contains("Must find action functions from script")))) {
             // As long as the executor position has not surpassed the threshold for which
             // a stream is considered unrecoverable, we can try to renew the playback URL with
             // another client.
@@ -213,10 +213,12 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     StreamFormat format = formats.getBestFormat();
 
-    URI resolvedUrl = sourceManager.getCipherManager()
-        .resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), format);
-
-    resolvedUrl = client.transformPlaybackUri(format.getUrl(), resolvedUrl);
+    URI resolvedUrl = format.getUrl();
+    if (client.requiresJSScript()) {
+      resolvedUrl = sourceManager.getCipherManager()
+              .resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), format);
+      resolvedUrl = client.transformPlaybackUri(format.getUrl(), resolvedUrl);
+    }
 
     return new FormatWithUrl(format, resolvedUrl);
   }

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -217,7 +217,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     StreamFormat format = formats.getBestFormat();
 
     URI resolvedUrl = format.getUrl();
-    if (client.requiresJSScript()) {
+    if (client.requirePlayerScript()) {
       resolvedUrl = sourceManager.getCipherManager()
               .resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), format);
       resolvedUrl = client.transformPlaybackUri(format.getUrl(), resolvedUrl);

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -17,6 +17,7 @@ import dev.lavalink.youtube.ClientInformation;
 import dev.lavalink.youtube.UrlTools;
 import dev.lavalink.youtube.UrlTools.UrlInfo;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.cipher.ScriptExtractionException;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import dev.lavalink.youtube.track.format.StreamFormat;
 import dev.lavalink.youtube.track.format.TrackFormats;
@@ -104,16 +105,13 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
             continue;
           }
 
-          String message = e.getMessage();
-
-          if ("Not success status code: 403".equals(message) ||
-              "Invalid status code for player api response: 400".equals(message) ||
-                  (message != null && (message.contains("No supported audio streams available") ||
-                          message.contains("Must find action functions from script") ||
-                          message.contains("Must find timestamp from script") ||
-                          message.contains("Must find decipher function from script") ||
-                          message.contains("Must find n function from script")
-                  ))) {
+          if (e instanceof ScriptExtractionException) {
+            // If we're still early in playback, we can try another client
+            if (localExecutor.getPosition() <= BAD_STREAM_POSITION_THRESHOLD_MS) {
+              continue;
+            }
+          } else if ("Not success status code: 403".equals(e.getMessage()) ||
+                  "Invalid status code for player api response: 400".equals(e.getMessage())) {
             // As long as the executor position has not surpassed the threshold for which
             // a stream is considered unrecoverable, we can try to renew the playback URL with
             // another client.

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -115,7 +115,7 @@ public class YoutubeRestHandler {
             log.debug("Selected format {} for {}", selectedFormat.getItag(), videoId);
 
             URI transformed = selectedFormat.getUrl();
-            if (client.requiresJSScript()) {
+            if (client.requirePlayerScript()) {
                 URI resolved = source.getCipherManager().resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), selectedFormat);
                 transformed = client.transformPlaybackUri(selectedFormat.getUrl(), resolved);
             }

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -114,8 +114,12 @@ public class YoutubeRestHandler {
 
             log.debug("Selected format {} for {}", selectedFormat.getItag(), videoId);
 
-            URI resolved = source.getCipherManager().resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), selectedFormat);
-            URI transformed = client.transformPlaybackUri(selectedFormat.getUrl(), resolved);
+            URI transformed = selectedFormat.getUrl();
+            if (client.requiresJSScript()) {
+                URI resolved = source.getCipherManager().resolveFormatUrl(httpInterface, formats.getPlayerScriptUrl(), selectedFormat);
+                transformed = client.transformPlaybackUri(selectedFormat.getUrl(), resolved);
+            }
+
             YoutubePersistentHttpStream httpStream = new YoutubePersistentHttpStream(httpInterface, transformed, selectedFormat.getContentLength());
 
             boolean streamValidated = false;


### PR DESCRIPTION
This PR adds a `requiresJSScript()` method to the `Client` interface to control whether a player script is needed for cipher operations. It updates mobile clients (Android, iOS) to **bypass** unnecessary player script fetching and processing.

**Changes:**
- Introduced `requiresJSScript()` in the `Client` interface, defaulting to `true`.
- Overridden `requiresJSScript()` to return `false` in mobile clients (`Android`, `Ios`).
- Modified `NonMusicClient`, `YoutubeAudioTrack`, and `YoutubeRestHandler` to check `requiresJSScript()` before attempting player script operations.
- Improved error recovery for cipher-related failures in `YoutubeAudioTrack`.

## Motivation

Mobile clients (Android and iOS) do not require YouTube player script deciphering, as their playback URLs are already accessible without it.  
Skipping player script usage:
- Reduces unnecessary HTTP requests.
- Improves playback speed for mobile clients.
- Makes playback more robust against YouTube player script changes.