### PR TITLE
fix n sig transformation

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipher.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/SignatureCipher.java
@@ -43,8 +43,8 @@ public class SignatureCipher {
                       @NotNull ScriptEngine scriptEngine) throws ScriptException, NoSuchMethodException {
     String transformed;
 
-    scriptEngine.eval(globalVars + ";" + sigActions + ";sig=" + sigFunction);
-    transformed = (String) ((Invocable) scriptEngine).invokeFunction("sig", text);
+    scriptEngine.eval(globalVars + ";" + sigActions + ";decrypt_sig=" + sigFunction);
+    transformed = (String) ((Invocable) scriptEngine).invokeFunction("decrypt_sig", text);
     return transformed;
   }
 
@@ -87,8 +87,8 @@ public class SignatureCipher {
       throws ScriptException, NoSuchMethodException {
     String transformed;
 
-    scriptEngine.eval(globalVars + ";n=" + nFunction);
-    transformed = (String) ((Invocable) scriptEngine).invokeFunction("n", text);
+    scriptEngine.eval(globalVars + ";decrypt_nsig=" + nFunction);
+    transformed = (String) ((Invocable) scriptEngine).invokeFunction("decrypt_nsig", text);
 
     return transformed;
   }


### PR DESCRIPTION
Script https://www.youtube.com/s/player/461f4c95/player_ias.vflset/pl_PL/base.js has tce global variable name as `n` but in `SignatureCipher` class transform method we redefining a function with name `n` . Due to that it got failed to transform n sig