### PR TITLE
Fix EMBEDDER_IDENTITY_DENIED errors and add encryptedHostFlags support

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/ClientConfig.java
@@ -132,6 +132,15 @@ public class ClientConfig {
         return this;
     }
 
+    public ClientConfig withEncryptedHostFlags(@Nullable String encryptedHostFlags) {
+        if (encryptedHostFlags != null) {
+            Map<String, Object> playbackContext = putOnceAndJoin(root, "playbackContext");
+            Map<String, Object> contentPlaybackContext = putOnceAndJoin(playbackContext, "contentPlaybackContext");
+            contentPlaybackContext.put("encryptedHostFlags", encryptedHostFlags);
+        }
+        return this;
+    }
+
     public ClientConfig withRootField(@NotNull String key,
                                       @Nullable Object value) {
         root.put(key, value);


### PR DESCRIPTION
## Summary

- Skip embed workaround (`clientScreen: EMBED` + `embedUrl: https://google.com`) for OAuth-supporting clients to avoid `PLAYABILITY_ERROR_CODE_EMBEDDER_IDENTITY_DENIED` errors
- For embedded clients, fetch `encryptedHostFlags` from the YouTube embed page and include it in player requests
- Add `withEncryptedHostFlags()` method to `ClientConfig`

## Problem

YouTube started returning `PLAYABILITY_ERROR_CODE_EMBEDDER_IDENTITY_DENIED` (error code 152-18) when using the embed workaround with OAuth-authenticated clients. The fake `embedUrl: "https://google.com"` triggers this restriction.

## Solution

1. **OAuth clients**: Skip the embed workaround entirely - OAuth authentication is sufficient without pretending to be an embedded player
2. **Embedded clients**: Fetch the real `encryptedHostFlags` from the embed page (approach from PR #191 by @Nansess)

## Testing

Tested with `TVHTML5_SIMPLY_EMBEDDED_PLAYER` client - now returns `"status":"OK"` with full streaming data instead of the embed identity error.

## Related

Incorporates the `encryptedHostFlags` approach from #191 by @Nansess, combined with the OAuth client fix.