### PR TITLE
Fix: Ensure consistent character encoding in HTTP response handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ replay_pid*
 */build/*
 build
 .vscode/*
+.cursor/*
 
 application.yml
 playerconfigs/*

--- a/common/src/main/java/dev/lavalink/youtube/cipher/CipherManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/CipherManager.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -41,7 +42,7 @@ public interface CipherManager {
             try (CloseableHttpResponse response = httpInterface.execute(new HttpGet("https://www.youtube.com/embed/"))) {
                 HttpClientTools.assertSuccessWithContent(response, "fetch player script (embed)");
 
-                String responseText = EntityUtils.toString(response.getEntity());
+                String responseText = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 String scriptUrl = DataFormatTools.extractBetween(responseText, "\"jsUrl\":\"", "\"");
 
                 if (scriptUrl == null) {

--- a/common/src/main/java/dev/lavalink/youtube/clients/Web.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/Web.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class Web extends StreamingNonMusicClient {
             HttpClientTools.assertSuccessWithContent(response, "client config fetch");
             lastConfigUpdate = System.currentTimeMillis();
 
-            String page = EntityUtils.toString(response.getEntity());
+            String page = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             Matcher m = CONFIG_REGEX.matcher(page);
 
             if (!m.find()) {

--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -74,7 +74,7 @@ public abstract class NonMusicClient implements Client {
             //       from my testing, json is always returned so might not be necessary.
             HttpClientTools.assertJsonContentType(response);
 
-            String json = EntityUtils.toString(response.getEntity());
+            String json = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             log.trace("Response from {} ({}) {}", request.getURI(), context, json);
 
             return JsonBrowser.parse(json);
@@ -209,7 +209,7 @@ public abstract class NonMusicClient implements Client {
             request.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
 
             HttpResponse response = httpClient.execute(request);
-            String html = EntityUtils.toString(response.getEntity());
+            String html = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
             Pattern pattern = Pattern.compile("\"encryptedHostFlags\":\"([^\"]+)\"");
             Matcher matcher = pattern.matcher(html);

--- a/common/src/test/java/CipherManagerTest.java
+++ b/common/src/test/java/CipherManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -229,7 +230,7 @@ public class CipherManagerTest {
      */
     private String fetchCurrentPlayerScriptUrl(HttpInterface httpInterface) throws IOException {
         try (CloseableHttpResponse response = httpInterface.execute(new HttpGet("https://www.youtube.com/embed/"))) {
-            String responseText = EntityUtils.toString(response.getEntity());
+            String responseText = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             
             // Extract the jsUrl from the response
             Pattern jsUrlPattern = Pattern.compile("\"jsUrl\":\"([^\"]+)\"");


### PR DESCRIPTION
## Summary

This PR ensures that calls to `EntityUtils.toString` specify UTF_8 character encoding. This resolves issues with [mojibake](https://en.wikipedia.org/wiki/Mojibake) when system default character encoding is NOT UTF_8.


## Commit Message

Updated EntityUtils.toString calls to specify StandardCharsets.UTF_8 for consistent character encoding across multiple classes, including CipherManager, Web, and NonMusicClient. 

Added .cursor to .gitignore to exclude cursor files from version control.