### PR TITLE
fix: remove broken playlist support in TvHtml5Simply

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,18 +184,18 @@ plugins:
 ## Available Clients
 Currently, the following clients are available for use:
 
-| Identifier        | Opus Formats | OAuth | Age-restriction Support | Playback Support | Metadata Support             | Additional Notes                                     |
-|-------------------|--------------|-------|-------------------------|------------------|------------------------------|------------------------------------------------------|
-| `MUSIC`           | No           | No    | No                      | No               | Search                       | YouTube music search support via `ytmsearch:` prefix |
-| `WEB`             | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix |                                                      |
-| `MWEB`            | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix |                                                      |
-| `WEBEMBEDDED`     | Yes          | No    | Limited                 | Yes + Livestream | Video                        |                                                      |
-| `ANDROID`         | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix | Heavily restricted, frequently dysfunctional         |
-| `ANDROID_MUSIC`   | Yes          | No    | No                      | Yes              | Video, Search, Mix           |                                                      |
-| `ANDROID_VR`      | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix |                                                      |
-| `IOS`             | No           | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix |                                                      |
-| `TV`              | Yes          | Yes   | With OAuth              | Yes + Livestream | None                         | Playback requires sign-in                            |
-| `TVHTML5_SIMPLY`  | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix            |                                                      |
+| Identifier        | Opus Formats | OAuth | Age-restriction Support | Playback Support | Metadata Support              | Additional Notes                                     |
+|-------------------|--------------|-------|-------------------------|------------------|-------------------------------|------------------------------------------------------|
+| `MUSIC`           | No           | No    | No                      | No               | Search                        | YouTube music search support via `ytmsearch:` prefix |
+| `WEB`             | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix  |                                                      |
+| `MWEB`            | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix  |                                                      |
+| `WEBEMBEDDED`     | Yes          | No    | Limited                 | Yes + Livestream | Video                         |                                                      |
+| `ANDROID`         | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix  | Heavily restricted, frequently dysfunctional         |
+| `ANDROID_MUSIC`   | Yes          | No    | No                      | Yes              | Video, Search, Mix            |                                                      |
+| `ANDROID_VR`      | Yes          | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix  |                                                      |
+| `IOS`             | No           | No    | No                      | Yes + Livestream | Video, Search, Playlist, Mix  |                                                      |
+| `TV`              | Yes          | Yes   | With OAuth              | Yes + Livestream | None                          | Playback requires sign-in                            |
+| `TVHTML5_SIMPLY`  | Yes          | No    | No                      | Yes + Livestream | Video, Search, Mix            |                                                      |
 
 > [!NOTE]
 > Clients that do not return Opus formats will require transcoding.

--- a/common/src/main/java/dev/lavalink/youtube/clients/TvHtml5Simply.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/TvHtml5Simply.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class TvHtml5Simply extends StreamingNonMusicClient {
-    
+
     public static ClientConfig BASE_CONFIG = new ClientConfig()
             .withClientName("TVHTML5_SIMPLY")
             .withClientField("clientVersion", "1.0")
@@ -46,7 +46,7 @@ public class TvHtml5Simply extends StreamingNonMusicClient {
 
     @Override
     public boolean canHandleRequest(@NotNull String identifier) {
-        return super.canHandleRequest(identifier);
+        return !identifier.contains("list=") && super.canHandleRequest(identifier);
     }
 
     @Override


### PR DESCRIPTION
Can't figure out why there's no continuation token for TV Simply pagination, but until it's fixed (if it's even fixable), playlist metadata should fallback to other clients that have a working implementation.

related to #212