### PR TITLE
fix: live stream HTTP 400 and missing title/author metadata

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
+++ b/common/src/main/java/dev/lavalink/youtube/clients/skeleton/NonMusicClient.java
@@ -224,6 +224,38 @@ public abstract class NonMusicClient implements Client {
         return null;
     }
 
+    /**
+     * Fetches title and author from the public YouTube oEmbed endpoint.
+     * This works for any public video (including login-required content and live streams)
+     * without requiring authentication. Used as a last-resort fallback when the InnerTube
+     * player response omits videoDetails.title / videoDetails.author (e.g. TVHTML5+OAuth).
+     *
+     * @param videoId the YouTube video ID
+     * @return a JsonBrowser containing "title" and "author_name", or null on failure
+     */
+    @Nullable
+    protected JsonBrowser fetchOEmbed(@NotNull String videoId) {
+        String url = "https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D" + videoId + "&format=json";
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet request = new HttpGet(url);
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+
+                if (statusCode != 200) {
+                    log.debug("oEmbed returned status {} for videoId {}", statusCode, videoId);
+                    return null;
+                }
+
+                return JsonBrowser.parse(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            log.debug("oEmbed request failed for videoId {}", videoId, e);
+            return null;
+        }
+    }
+
     @NotNull
     protected JsonBrowser loadSearchResults(@NotNull HttpInterface httpInterface,
                                             @NotNull String searchQuery) {
@@ -433,11 +465,60 @@ public abstract class NonMusicClient implements Client {
         JsonBrowser playabilityStatus = json.get("playabilityStatus");
         JsonBrowser videoDetails = json.get("videoDetails");
 
-        String title = videoDetails.get("title").text();
+        // videoDetails.title is a plain string for most clients/content, but TVHTML5 + OAuth
+        // responses for login-required content omit it entirely from videoDetails.
+        // Try the field itself in all known formats, then fall back to both known microformat
+        // renderers. TVHTML5 uses playerMicroformatRenderer; web clients use microformatDataRenderer.
+        JsonBrowser titleNode = videoDetails.get("title");
+        String title = DataFormatTools.defaultOnNull(
+            titleNode.text(),
+            DataFormatTools.defaultOnNull(
+                titleNode.get("simpleText").text(),
+                titleNode.get("runs").index(0).get("text").text()
+            )
+        );
+
+        if (title == null) {
+            // TV-client responses (TVHTML5) use playerMicroformatRenderer.title.simpleText
+            title = json.get("microformat").get("playerMicroformatRenderer").get("title").get("simpleText").text();
+        }
+        if (title == null) {
+            // Web-client responses use microformatDataRenderer.title (plain string)
+            title = json.get("microformat").get("microformatDataRenderer").get("title").text();
+        }
+        // author: same pattern — plain string in videoDetails for most clients;
+        // TVHTML5 exposes it as playerMicroformatRenderer.ownerChannelName.
         String author = videoDetails.get("author").text();
 
         if (author == null) {
-            log.debug("Author field is null, client: {}, json: {}", getIdentifier(), json.format());
+            author = json.get("microformat").get("playerMicroformatRenderer").get("ownerChannelName").text();
+        }
+        if (author == null) {
+            author = json.get("microformat").get("microformatDataRenderer").get("pageOwnerDetails").get("name").text();
+        }
+
+        // If title or author is still missing (e.g. TVHTML5+OAuth omits them for login-required
+        // content), fall back to the public oEmbed endpoint which works for any public video.
+        if (title == null || author == null) {
+            JsonBrowser oEmbed = fetchOEmbed(videoId);
+            if (oEmbed != null) {
+                if (title == null) {
+                    title = oEmbed.get("title").text();
+                }
+                if (author == null) {
+                    author = oEmbed.get("author_name").text();
+                }
+            }
+        }
+
+        if (title == null) {
+            log.warn("Could not extract title for client {}, videoId {}. microformat: {}",
+                getIdentifier(), videoId, json.get("microformat").format());
+            title = "Unknown title";
+        }
+        if (author == null) {
+            log.warn("Could not extract author for client {}, videoId {}. microformat: {}",
+                getIdentifier(), videoId, json.get("microformat").format());
             author = "Unknown artist";
         }
 

--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeMpegStreamAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeMpegStreamAudioTrack.java
@@ -90,7 +90,21 @@ public class YoutubeMpegStreamAudioTrack extends MpegAudioTrack {
     }
 
     private void updateGlobalSequence() {
-        try (YoutubePersistentHttpStream stream = new YoutubePersistentHttpStream(httpInterface, state.initialUrl, CONTENT_LENGTH_UNKNOWN)) {
+        URI urlToFetch = state.initialUrl;
+
+        if (trackInfo.isStream) {
+            // Live broadcast URLs (noclen=1, live=1) reject HTTP range requests with 400.
+            // YoutubePersistentHttpStream adds &range=0-N whenever the URL lacks "rn=".
+            // Adding rn=0 here causes getConnectUrl() to return the URL as-is, bypassing
+            // the range logic so we can fetch the current live segment without a 400.
+            try {
+                urlToFetch = new URIBuilder(state.initialUrl).setParameter("rn", "0").build();
+            } catch (URISyntaxException e) {
+                return;
+            }
+        }
+
+        try (YoutubePersistentHttpStream stream = new YoutubePersistentHttpStream(httpInterface, urlToFetch, CONTENT_LENGTH_UNKNOWN)) {
             MpegFileLoader file = new MpegFileLoader(stream);
             file.parseHeaders();
 
@@ -108,6 +122,10 @@ public class YoutubeMpegStreamAudioTrack extends MpegAudioTrack {
     private void execute(LocalAudioTrackExecutor localExecutor) throws InterruptedException {
         if (!trackInfo.isStream && state.absoluteSequence == null) {
             state.absoluteSequence = 0L;
+        }
+
+        if (trackInfo.isStream) {
+            log.info("Starting livestream playback: {} / {}", trackInfo.title, trackInfo.author);
         }
 
         try {
@@ -166,8 +184,6 @@ public class YoutubeMpegStreamAudioTrack extends MpegAudioTrack {
         LocalAudioTrackExecutor localExecutor
     ) throws InterruptedException {
         URI segmentUrl = getNextSegmentUrl(state);
-
-        log.debug("Segment URL: {}", segmentUrl.toString());
 
         try (YoutubePersistentHttpStream stream = new YoutubePersistentHttpStream(httpInterface, segmentUrl, CONTENT_LENGTH_UNKNOWN)) {
             if (stream.checkStatusCode() == HttpStatus.SC_NO_CONTENT || stream.getContentLength() == 0) {


### PR DESCRIPTION
## Summary

Two bugs that surface specifically with live streams and login-required content.

---

### 1. HTTP 400 when initializing live stream playback

**File:** `YoutubeMpegStreamAudioTrack.java`

`updateGlobalSequence()` fetches the current segment on stream start to read the sequence number. `YoutubePersistentHttpStream` appends a `&range=0-N` query parameter to any URL that does not already contain an `rn=` parameter.

Live broadcast URLs carry `noclen=1` and `live=1`. YouTube's live segment servers reject HTTP range requests with **HTTP 400**, so `updateGlobalSequence()` always fails for live streams and sequence tracking is broken.

**Fix:** when `trackInfo.isStream` is true, append `rn=0` to the URL before passing it to `YoutubePersistentHttpStream`. The stream class skips the range logic for any URL that already contains `rn=`, so the request goes through as a plain fetch and returns HTTP 200.

A per-segment `log.debug` that fires every few seconds for the lifetime of any live stream is also removed and replaced with a single `log.info` line when playback begins.

---

### 2. Missing title and author for TVHTML5 + OAuth responses

**File:** `NonMusicClient.java`

When a login-required video is loaded via the TV client with OAuth, the InnerTube player response returns a `videoDetails` object that contains `videoId` but omits `title` and `author`. The original code read `videoDetails.title` and `videoDetails.author` directly, so both fields come back null for this client/content combination.

**Fix:** a cascade of fallback paths is tried in order before giving up:

1. `videoDetails.title` as a plain string (existing behaviour)
2. `videoDetails.title.simpleText` (structured text node variant)
3. `videoDetails.title.runs[0].text` (rich text node variant)
4. `microformat.playerMicroformatRenderer.title.simpleText` (TV client microformat)
5. `microformat.microformatDataRenderer.title` (web client microformat)
6. `microformat.playerMicroformatRenderer.ownerChannelName` (TV client author)
7. `microformat.microformatDataRenderer.pageOwnerDetails.name` (web client author)
8. YouTube oEmbed endpoint (`https://www.youtube.com/oembed?url=...&format=json`) as a final fallback - this endpoint is public, requires no authentication, and returns `title` and `author_name` for any publicly accessible video including login-required content and live streams. It is only called when at least one field is still null after all InnerTube paths above have been exhausted.

## Test plan

- [ ] Load a standard YouTube video - title and author extract via `videoDetails` as before, oEmbed not called
- [ ] Load a login-required video via the TV client with OAuth - title and author populate from microformat or oEmbed fallback
- [ ] Start a YouTube live stream - no HTTP 400 on initialization, playback begins, single INFO log line appears
- [ ] Verify `log.debug("Segment URL: ...")` no longer fires every segment during live stream playback