### PR TITLE
fix: guard against missing sts in RemoteCipherManager.getTimestamp

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/cipher/RemoteCipherManager.java
+++ b/common/src/main/java/dev/lavalink/youtube/cipher/RemoteCipherManager.java
@@ -112,7 +112,13 @@ public class RemoteCipherManager implements CipherManager {
                 log.debug("Received response from remote cipher service: {}", responseBody);
 
                 JsonBrowser json = JsonBrowser.parse(responseBody);
-                return json.get("sts").text();
+                String sts = json.get("sts").text();
+
+                if (DataFormatTools.isNullOrEmpty(sts)) {
+                    throw new IOException("Remote cipher service did not return a signature timestamp (sts).");
+                }
+
+                return sts;
             }
         }
     }


### PR DESCRIPTION
## What
`RemoteCipherManager.getTimestamp()` returns `json.get("sts").text()` from the remote cipher server's `get_sts` response without validating it. If the server returns a successful (200) response that omits `sts`, `text()` returns null.

## Why it matters
- That null becomes `CachedPlayerScript.signatureTimestamp` and is cached for 24h (`expireTimestampMs = now + 1 day`).
- It then flows into `ClientConfig.withPlaybackSignatureTimestamp(...)` (`NonMusicClient` → `ClientConfig`), so a null signature timestamp ends up in the player request for a full day — surfacing later as a confusing playback failure with nothing pointing back at the cipher server.

## Change
- Add a null/empty guard that throws a clear `IOException`, mirroring the existing `resolved_url` guard a few lines down in `resolveUrl()`.
- Uses the already-imported `DataFormatTools.isNullOrEmpty`. No new imports, no signature changes (~6 lines).
- Since `getTimestamp` runs inside `getCachedPlayerScript`'s double-checked synchronized block, throwing means the bad value is never cached — the next request retries instead of being poisoned for 24h.

## Scope / non-goals
This hardens the remote cipher path only (the recommended path). It does **not** touch the local solver, adds no regex/indexOf logic, and re-enables no tests.
