### PR TITLE
Fix REST error compatibility across Spring 5 and 6

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     implementation(libs.nanojson)
     compileOnly(libs.slf4j)
     compileOnly(libs.annotations)
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0-M1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.0-M1")
 }
 
 java {
@@ -46,6 +49,9 @@ tasks.jar {
 }
 
 tasks {
+    test {
+        useJUnitPlatform()
+    }
     processResources {
         filter<ReplaceTokens>(
             "tokens" to mapOf(

--- a/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
+++ b/plugin/src/main/java/dev/lavalink/youtube/plugin/YoutubeRestHandler.java
@@ -44,7 +44,8 @@ public class YoutubeRestHandler {
         YoutubeAudioSourceManager source = playerManager.source(YoutubeAudioSourceManager.class);
 
         if (source == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The YouTube source manager is not registered.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST.value(),
+                "The YouTube source manager is not registered.", null);
         }
 
         return source;
@@ -58,7 +59,8 @@ public class YoutubeRestHandler {
         Throwable lastException = null;
 
         if (Arrays.stream(source.getClients()).noneMatch(Client::supportsFormatLoading)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "None of the registered clients supports format loading.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST.value(),
+                "None of the registered clients supports format loading.", null);
         }
 
         boolean foundFormats = false;
@@ -85,7 +87,8 @@ public class YoutubeRestHandler {
             try {
                 formats = client.loadFormats(source, httpInterface, videoId);
             } catch (CannotBeLoaded cbl) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "This video cannot be loaded. Reason: " + cbl.getCause().getMessage());
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST.value(),
+                    "This video cannot be loaded. Reason: " + cbl.getCause().getMessage(), null);
             }  catch (Throwable t) {
                 log.debug("Client \"{}\" threw a non-fatal exception, storing and proceeding...", client.getIdentifier());
                 t.addSuppressed(ClientInformation.create(client));
@@ -166,14 +169,17 @@ public class YoutubeRestHandler {
         IOUtils.closeQuietly(httpInterface);
 
         if (foundFormats) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No formats found with the requested itag.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST.value(),
+                "No formats found with the requested itag.", null);
         }
 
         if (lastException != null) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "This video cannot be loaded", lastException);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "This video cannot be loaded", lastException);
         }
 
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not find formats for the requested videoId.");
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST.value(),
+            "Could not find formats for the requested videoId.", null);
     }
 
     @GetMapping("/youtube")

--- a/plugin/src/test/java/dev/lavalink/youtube/plugin/YoutubeRestHandlerBinaryCompatibilityTest.java
+++ b/plugin/src/test/java/dev/lavalink/youtube/plugin/YoutubeRestHandlerBinaryCompatibilityTest.java
@@ -1,0 +1,47 @@
+package dev.lavalink.youtube.plugin;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class YoutubeRestHandlerBinaryCompatibilityTest {
+    private static final String HANDLER_CLASS =
+        "dev/lavalink/youtube/plugin/YoutubeRestHandler.class";
+    private static final String CROSS_VERSION_CONSTRUCTOR =
+        "(ILjava/lang/String;Ljava/lang/Throwable;)V";
+    private static final String SPRING_5_TWO_ARGUMENT_CONSTRUCTOR =
+        "(Lorg/springframework/http/HttpStatus;Ljava/lang/String;)V";
+    private static final String SPRING_5_THREE_ARGUMENT_CONSTRUCTOR =
+        "(Lorg/springframework/http/HttpStatus;Ljava/lang/String;Ljava/lang/Throwable;)V";
+    private static final String SPRING_6_TWO_ARGUMENT_CONSTRUCTOR =
+        "(Lorg/springframework/http/HttpStatusCode;Ljava/lang/String;)V";
+    private static final String SPRING_6_THREE_ARGUMENT_CONSTRUCTOR =
+        "(Lorg/springframework/http/HttpStatusCode;Ljava/lang/String;Ljava/lang/Throwable;)V";
+
+    @Test
+    public void responseStatusExceptionsUseCrossVersionConstructor() throws IOException {
+        String constantPool = readHandlerClassAsSingleByteText();
+
+        Assertions.assertTrue(constantPool.contains(CROSS_VERSION_CONSTRUCTOR),
+            "Expected the raw status code ResponseStatusException constructor.");
+        Assertions.assertFalse(constantPool.contains(SPRING_5_TWO_ARGUMENT_CONSTRUCTOR),
+            "Spring 5's HttpStatus constructor is not available on Spring 6.");
+        Assertions.assertFalse(constantPool.contains(SPRING_5_THREE_ARGUMENT_CONSTRUCTOR),
+            "Spring 5's HttpStatus constructor is not available on Spring 6.");
+        Assertions.assertFalse(constantPool.contains(SPRING_6_TWO_ARGUMENT_CONSTRUCTOR),
+            "Spring 6's HttpStatusCode constructor is not available on Spring 5.");
+        Assertions.assertFalse(constantPool.contains(SPRING_6_THREE_ARGUMENT_CONSTRUCTOR),
+            "Spring 6's HttpStatusCode constructor is not available on Spring 5.");
+    }
+
+    private static String readHandlerClassAsSingleByteText() throws IOException {
+        ClassLoader classLoader = YoutubeRestHandlerBinaryCompatibilityTest.class.getClassLoader();
+        try (InputStream input = classLoader.getResourceAsStream(HANDLER_CLASS)) {
+            Assertions.assertNotNull(input, "Compiled YoutubeRestHandler class was not found.");
+            return new String(input.readAllBytes(), StandardCharsets.ISO_8859_1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use the raw HTTP status-code `ResponseStatusException` constructor at all six REST error sites
- preserve the existing 400/500 behavior and causes
- add a classfile regression that rejects Spring-version-specific constructor descriptors

## Why
The plugin compiles against Spring 5 through Lavalink 3.7.11, where `ResponseStatusException` constructors accept `HttpStatus`. Lavalink 4.2.2 runs Spring 6, where those descriptors accept `HttpStatusCode` instead. The JVM therefore raises `NoSuchMethodError` when a REST error path is reached.

`ResponseStatusException(int, String, Throwable)` is available with the same descriptor in both Spring 5 and Spring 6, so this keeps the existing single-JAR compatibility model without changing the compile dependency.

## Validation
- `./gradlew :plugin:test :plugin:jar --no-daemon`
- `BUILD SUCCESSFUL`
- bytecode test requires `(ILjava/lang/String;Ljava/lang/Throwable;)V` and rejects both version-specific descriptors