### PR TITLE
Stream progressive itag 18 SABR-fallback contiguously

### DIFF
--- a/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
+++ b/common/src/main/java/dev/lavalink/youtube/track/YoutubeAudioTrack.java
@@ -18,6 +18,9 @@ import dev.lavalink.youtube.cipher.ScriptExtractionException;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import dev.lavalink.youtube.track.format.StreamFormat;
 import dev.lavalink.youtube.track.format.TrackFormats;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -132,10 +135,26 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     log.debug("Starting track with URL from client {}: {}", client.getIdentifier(), augmentedFormat.signedUrl);
 
     try {
-      if (trackInfo.isStream || augmentedFormat.format.getContentLength() == CONTENT_LENGTH_UNKNOWN) {
+      long contentLength = augmentedFormat.format.getContentLength();
+
+      if (!trackInfo.isStream && contentLength == CONTENT_LENGTH_UNKNOWN) {
+        // Some player responses (notably the itag 18 fallback returned when a client only
+        // exposes SABR-gated adaptive formats) omit contentLength even though the stream is
+        // a normal progressive file. Without a length it is treated as an OTF/segment stream
+        // and fails to decode. Probe the URL; if the CDN reports a concrete length, play it
+        // contiguously instead. Genuine OTF streams report no total and stay on the segment path.
+        long probedContentLength = probeContentLength(httpInterface, augmentedFormat.signedUrl);
+
+        if (probedContentLength != CONTENT_LENGTH_UNKNOWN) {
+          log.debug("Resolved missing content length for client {} via probe: {}", client.getIdentifier(), probedContentLength);
+          contentLength = probedContentLength;
+        }
+      }
+
+      if (trackInfo.isStream || contentLength == CONTENT_LENGTH_UNKNOWN) {
         processStream(localExecutor, httpInterface, augmentedFormat);
       } else {
-        processStatic(localExecutor, httpInterface, augmentedFormat, streamPosition);
+        processStatic(localExecutor, httpInterface, augmentedFormat, streamPosition, contentLength);
       }
     } catch (StreamExpiredException e) {
       processWithClient(localExecutor, httpInterface, client, e.lastStreamPosition);
@@ -145,11 +164,12 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
   private void processStatic(LocalAudioTrackExecutor localExecutor,
                              HttpInterface httpInterface,
                              FormatWithUrl augmentedFormat,
-                             long streamPosition) throws Exception {
+                             long streamPosition,
+                             long contentLength) throws Exception {
     YoutubePersistentHttpStream stream = null;
 
     try {
-      stream = new YoutubePersistentHttpStream(httpInterface, augmentedFormat.signedUrl, augmentedFormat.format.getContentLength());
+      stream = new YoutubePersistentHttpStream(httpInterface, augmentedFormat.signedUrl, contentLength);
 
       if (streamPosition > 0) {
         stream.seek(streamPosition);
@@ -182,6 +202,57 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     // TODO: Catch 403 and retry? Can't use position though because it's a livestream.
     processDelegate(new YoutubeMpegStreamAudioTrack(trackInfo, httpInterface, augmentedFormat.signedUrl), localExecutor);
+  }
+
+  /**
+   * Probes a stream URL with a zero-length ranged request to discover its total content length
+   * when the player response omitted one. Returns CONTENT_LENGTH_UNKNOWN if it cannot be
+   * determined, in which case the caller falls back to segment streaming.
+   */
+  private long probeContentLength(HttpInterface httpInterface, URI url) {
+    HttpGet request = new HttpGet(url);
+    request.setHeader("Range", "bytes=0-0");
+
+    try (CloseableHttpResponse response = httpInterface.execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+
+      if (statusCode != 200 && statusCode != 206) {
+        return CONTENT_LENGTH_UNKNOWN;
+      }
+
+      Header contentRange = response.getFirstHeader("Content-Range");
+
+      if (contentRange != null) {
+        String value = contentRange.getValue();
+        int slashIndex = value.lastIndexOf('/');
+
+        if (slashIndex != -1) {
+          String total = value.substring(slashIndex + 1).trim();
+
+          if (!total.isEmpty() && !"*".equals(total)) {
+            long length = Long.parseLong(total);
+
+            if (length > 0) {
+              return length;
+            }
+          }
+        }
+      }
+
+      Header contentLengthHeader = response.getFirstHeader("Content-Length");
+
+      if (statusCode == 200 && contentLengthHeader != null) {
+        long length = Long.parseLong(contentLengthHeader.getValue().trim());
+
+        if (length > 0) {
+          return length;
+        }
+      }
+    } catch (Exception e) {
+      log.debug("Failed to probe content length for {}", url, e);
+    }
+
+    return CONTENT_LENGTH_UNKNOWN;
   }
 
   @NotNull


### PR DESCRIPTION
## Problem

Fixes #221.

When a streaming client's `/player` response comes back SABR-gated (every adaptive `itag` logged as `missing format URL for itag 'N'. SABR response?`), the plugin correctly falls back to the one format that still carries a URL — muxed **itag 18**. But that format arrives **without `contentLength`**, so `YoutubeAudioTrack.processWithClient` sends it down the OTF/segment path (`YoutubeMpegStreamAudioTrack`):

```java
if (trackInfo.isStream || augmentedFormat.format.getContentLength() == CONTENT_LENGTH_UNKNOWN) {
  processStream(...);   // OTF segment reader
} else {
  processStatic(...);   // contiguous
}
```

The itag 18 URL is actually a normal, complete, range-seekable progressive MP4 — a `HEAD`/ranged `GET` returns `200`/`206`, `video/mp4`, a real `Content-Length`, valid `ftyp`/`moov`, and the appended `&sq=`/`&rn=` segment params are ignored (the whole file is returned). The segment reader mis-frames it and the AAC decoder aborts at position 0 (`Expected decoding to halt, got: 5`), so the track fails with `loadFailed`.

On nodes where SABR affects the only playability-passing client (e.g. `TVHTML5` + OAuth on a datacenter IP), this makes the itag 18 fallback — the last usable stream — unplayable, i.e. no audio plays at all.

## Change

When a format has a URL and `contentLength == CONTENT_LENGTH_UNKNOWN` for a **non-live** track, probe the URL with a `Range: bytes=0-0` request and read the total length from `Content-Range` (falling back to `Content-Length`). If a concrete length is found, stream it contiguously via `processStatic`; otherwise fall back to `processStream` as before.

- The probe only runs when `contentLength` is missing, so the healthy path (normal adaptive formats that carry a length) is untouched.
- Genuine OTF/live streams report no total (or `*`) and correctly stay on the segment path, so there is no regression there.

## Verification

Built on top of current `main` (07180c1f) and run in production against videos that reproduced the failure. With the change, the itag 18 fallback resolves its length via the probe, is streamed via `YoutubePersistentHttpStream` + `MpegAudioTrack`, and decodes cleanly — playback restored, zero decode failures across many previously-failing tracks.

Happy to adjust the approach (e.g. `HEAD` instead of a ranged `GET`, or gating it more narrowly) and to add tests if you'd like.
